### PR TITLE
fix(silent-sso): tear down Tide enclave on logout instead of sending a dokenless refresh

### DIFF
--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -31,6 +31,15 @@ import { RequestEnclave, ApprovalEnclave, ApprovalEnclaveNew } from "heimdall-ti
 
 const CONTENT_TYPE_JSON = 'application/json'
 
+// Post-logout marker. After an explicit logout there is no session to silently
+// resume, so the immediately-following init() must skip the racy silent
+// check-sso (whose hidden iframe can net::ERR_ABORTED and wedge the app) and go
+// straight to interactive login. `logout()` stamps this durable localStorage
+// marker (survives the logout redirect round-trip); init() consumes it exactly
+// once and forces an interactive login when present + fresh.
+const POST_LOGOUT_MARKER_KEY = 'tide-post-logout'
+const POST_LOGOUT_MARKER_TTL_MS = 60000
+
 /**
  * @typedef {Object} Endpoints
  * @property {() => string} authorize
@@ -950,6 +959,15 @@ export default class TideCloak {
     }
 
     const onLoad = async () => {
+      // Post-logout deterministic path: if the previous logout stamped a fresh
+      // marker, skip silent check-sso entirely and go straight to interactive
+      // login. There is no session to silently resume after an explicit logout,
+      // and the silent path is exactly where the ERR_ABORTED wedge lives.
+      if (this.#consumePostLogoutMarker()) {
+        console.log('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
+        await doLogin(true)
+        return
+      }
       switch (initOptions.onLoad) {
         case 'check-sso':
           if (this.#loginIframe.enable) {
@@ -1092,23 +1110,38 @@ export default class TideCloak {
    * @returns {Promise<void>}
    */
   async #checkSsoSilently () {
+    console.log('[TIDE-SILENTSSO] start (timeout=' + this.silentCheckSsoTimeout + 'ms)')
     const iframe = document.createElement('iframe')
-    const src = await this.createLoginUrl({ prompt: 'none', redirectUri: this.silentCheckSsoRedirectUri })
-    iframe.setAttribute('src', src)
-    iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin')
-    iframe.setAttribute('title', 'keycloak-silent-check-sso')
-    iframe.style.display = 'none'
-    document.body.appendChild(iframe)
 
-    return await new Promise((resolve, reject) => {
+    return await new Promise((resolve) => {
       let settled = false
       /** @type {ReturnType<typeof setTimeout>=} */
       let timer
+      /** @type {ReturnType<typeof setTimeout>=} */
+      let loadGraceTimer
 
       const cleanup = () => {
         if (timer) clearTimeout(timer)
+        if (loadGraceTimer) clearTimeout(loadGraceTimer)
         window.removeEventListener('message', messageCallback)
+        iframe.removeEventListener('error', onIframeError)
+        iframe.removeEventListener('load', onIframeLoad)
         if (iframe.parentNode) document.body.removeChild(iframe)
+      }
+
+      // Every NON-authenticating terminal outcome funnels through here exactly
+      // once: onerror / onabort / load-without-message / timeout /
+      // createLoginUrl-failure. Resolving (never rejecting) as NOT-authenticated
+      // lets init() complete cleanly so the app falls through to interactive
+      // login. This is what makes the silent path structurally un-hangable: no
+      // matter which DOM event (or none) the aborted iframe produces, one of
+      // these fires. `via` is logged so QA can prove which path was taken.
+      const settleNotAuthenticated = (via) => {
+        if (settled) return
+        settled = true
+        console.warn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
+        cleanup()
+        resolve()
       }
 
       /**
@@ -1120,36 +1153,65 @@ export default class TideCloak {
         }
         if (settled) return
         settled = true
-
-        const oauth = this.#parseCallback(event.data)
         cleanup()
 
         try {
+          const oauth = this.#parseCallback(event.data)
           await this.#processCallback(oauth)
+          console.log('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
           resolve()
         } catch (error) {
-          reject(error)
+          // A failed silent callback must NOT reject: rejecting would surface as
+          // an init() error / AuthWall wall instead of a clean fall-through to
+          // interactive login. Resolve as not-authenticated.
+          console.warn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated:', error instanceof Error ? error.message : String(error))
+          resolve()
         }
       }
 
-      // Fail-fast guard: a silent check-sso must NEVER hang the init() promise.
-      // After an SDK-driven logout the doken/DPoP key is flushed; if the hidden
-      // check-sso iframe (or the Tide request enclave it may spin up) never
-      // posts back, init() would otherwise never resolve, isInitializing would
-      // stay true, and the SPA would wedge on "Signing you in..." forever
-      // (observed hang: 80s+). Resolve as NOT authenticated so init() completes
-      // cleanly and the app can fall through to an interactive login (which
-      // recovers). The happy path (valid session posts back in ~1-2s) settles
-      // well before this fires, so it is unchanged.
-      timer = setTimeout(() => {
-        if (settled) return
-        settled = true
-        this.#logWarn('[TIDECLOAK] Silent check-sso timed out after ' + this.silentCheckSsoTimeout + 'ms; treating as unauthenticated so the app can fall through to interactive login.')
-        cleanup()
-        resolve()
-      }, this.silentCheckSsoTimeout)
+      const onIframeError = () => settleNotAuthenticated('onerror')
 
+      const onIframeLoad = () => {
+        // The iframe finished navigating. On the happy path it landed on the
+        // real silent-check-sso.html and `messageCallback` settles first. If it
+        // loaded an error page, or a cross-origin KC page that never posts, or
+        // an aborted navigation that still fired `load`, no message arrives - so
+        // arm a short grace timer that settles NOT-authenticated well before the
+        // outer ceiling.
+        if (settled) return
+        const grace = Math.max(250, Math.min(2000, Math.floor(this.silentCheckSsoTimeout / 4)))
+        if (loadGraceTimer) clearTimeout(loadGraceTimer)
+        loadGraceTimer = setTimeout(() => settleNotAuthenticated('load-no-message'), grace)
+      }
+
+      // Wire ALL listeners before the navigation starts so no immediate event is
+      // missed. `error` covers the browsers that surface a failed iframe
+      // navigation as an error/abort event; `load` + the grace timer cover the
+      // ones that fire load on an error document; the outer `timer` covers
+      // net::ERR_ABORTED that produces NO DOM event at all.
       window.addEventListener('message', messageCallback)
+      iframe.addEventListener('error', onIframeError)
+      iframe.addEventListener('load', onIframeLoad)
+
+      // Hard ceiling. Created synchronously (NOT after an awaited createLoginUrl)
+      // so it is always armed regardless of what the iframe navigation does.
+      timer = setTimeout(() => settleNotAuthenticated('timeout'), this.silentCheckSsoTimeout)
+
+      // Build the URL and start the navigation. Failure here must still settle
+      // (not reject) so init() stays deterministic.
+      this.createLoginUrl({ prompt: 'none', redirectUri: this.silentCheckSsoRedirectUri })
+        .then((src) => {
+          if (settled) return
+          iframe.setAttribute('src', src)
+          iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin')
+          iframe.setAttribute('title', 'keycloak-silent-check-sso')
+          iframe.style.display = 'none'
+          document.body.appendChild(iframe)
+        })
+        .catch((error) => {
+          console.warn('[TIDE-SILENTSSO] createLoginUrl failed:', error instanceof Error ? error.message : String(error))
+          settleNotAuthenticated('createLoginUrl-error')
+        })
     })
   };
 
@@ -1454,7 +1516,43 @@ export default class TideCloak {
    */
   logout = async (options) => {
     await this.#dpopProvider?.flush()
+    // Stamp the post-logout marker so the next init() forces interactive login
+    // instead of running the racy silent check-sso. See POST_LOGOUT_MARKER_KEY.
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(POST_LOGOUT_MARKER_KEY, Date.now().toString())
+        console.log('[TIDE-POSTLOGOUT] marker set in logout(); next init() will force interactive login (skip silent check-sso)')
+      }
+    } catch (e) {
+      console.warn('[TIDE-POSTLOGOUT] could not set marker:', e instanceof Error ? e.message : String(e))
+    }
     return this.#adapter.logout(options)
+  }
+
+  /**
+   * Read + clear the post-logout marker. Returns true only when a marker was
+   * present AND fresh (set within POST_LOGOUT_MARKER_TTL_MS). Always clears the
+   * marker when present, so it fires at most once and a stale marker (a tab
+   * left open across a much later load) is discarded rather than forcing an
+   * unexpected interactive login.
+   * @returns {boolean}
+   */
+  #consumePostLogoutMarker () {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) return false
+      const raw = window.localStorage.getItem(POST_LOGOUT_MARKER_KEY)
+      if (!raw) return false
+      window.localStorage.removeItem(POST_LOGOUT_MARKER_KEY)
+      const ts = Number(raw)
+      const fresh = Number.isFinite(ts) && (Date.now() - ts) < POST_LOGOUT_MARKER_TTL_MS
+      if (!fresh) {
+        console.warn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
+      }
+      return fresh
+    } catch (e) {
+      console.warn('[TIDE-POSTLOGOUT] could not read marker:', e instanceof Error ? e.message : String(e))
+      return false
+    }
   }
 
   /**

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -1792,7 +1792,10 @@ export default class TideCloak {
    * Make sure enclave is up - attach this function to a user gesture.
    */
   #ensureRequestEnclaveOpen() {
-    if(!this.requestEnclave) return;
+    // Never (re)open the enclave without a doken. Post-logout the doken is
+    // flushed; reopening a dokenless hidden enclave wedges it with
+    // "Expecting doken in request".
+    if(!this.requestEnclave || !this.doken) return;
     this.requestEnclave.checkEnclaveOpen();
   }
 
@@ -2232,9 +2235,35 @@ export default class TideCloak {
     } else {
       delete this.doken
       delete this.dokenParsed
-      if (this.requestEnclave && typeof this.requestEnclave.updateDoken === 'function') {
-        this.requestEnclave.updateDoken(undefined)
+      // No doken present (e.g. post-logout / flushed state). Do NOT push a
+      // "doken refresh" into the enclave: refreshing with an undefined doken
+      // wedges the hidden enclave ("Expecting doken in request",
+      // TIDE-SWE-UNHANDLED) and blocks the silent re-auth that runs after
+      // logout. Instead tear the stale enclave(s) down so (a) no dokenless
+      // refresh is ever sent, (b) the persistent user-gesture listener can no
+      // longer reopen a dokenless hidden enclave (#ensureRequestEnclaveOpen
+      // no-ops once requestEnclave is cleared), and (c) the next authenticated
+      // flow re-creates a fresh enclave from a valid doken via
+      // initRequestEnclave(). The app is then free to fall through to an
+      // interactive login, which recovers cleanly.
+      this.#teardownEnclaves()
+    }
+  }
+
+  /**
+   * Close and discard any open Tide enclaves. Called when the doken is cleared
+   * (logout / flushed state) so stale enclaves can't be driven without a doken.
+   */
+  #teardownEnclaves () {
+    for (const key of ['requestEnclave', 'approvalEnclave']) {
+      const enclave = this[key]
+      if (!enclave) continue
+      try {
+        if (typeof enclave.close === 'function') enclave.close()
+      } catch (error) {
+        this.#logWarn('[TIDECLOAK] Failed to close ' + key + ': ' + (error instanceof Error ? error.message : error))
       }
+      this[key] = undefined
     }
   }
 

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -342,9 +342,29 @@ export default class TideCloak {
 
     this.onReady?.(this.authenticated)
 
-    // initialize request enclave if authenticated
-    if(this.doken && initOptions.setupRequestEnclave) {
-      this.initRequestEnclave();
+    // Do NOT eagerly open the Tide RequestEnclave during init().
+    //
+    // On a post-logout silent re-auth, the doken returned by the silent
+    // check-sso can be STALE: its session key no longer matches the session the
+    // hidden enclave cached from the previous login. Opening the hidden enclave
+    // here makes it sit "waiting for doken refresh" forever - a refresh that
+    // never comes because no fresh doken exists - which is exactly the
+    // "[ENCLAVE] Received init but waiting for doken refresh" ... hang that
+    // wedges the SPA on "Signing you in..." on the second login. (The enclave
+    // silently WAITS rather than emitting an error, so heimdall's own
+    // requireReloginCallback recovery never fires.)
+    //
+    // Instead we DEFER enclave setup: it is created lazily on the first real
+    // Tide operation (encrypt / decrypt / approve / signDpopApproval - each
+    // calls initRequestEnclave()), by which point a fresh interactive login has
+    // minted a current doken and the enclave can complete its handshake. We
+    // still register the user-gesture listener so the popup fallback can open
+    // once an enclave has actually been created; #ensureRequestEnclaveOpen
+    // no-ops while there is no enclave or no doken.
+    if (initOptions.setupRequestEnclave) {
+      if (this.doken) {
+        this.#logInfo('[TIDECLOAK] Deferring Tide RequestEnclave setup until first use (not opening during init to avoid a stale-doken handshake stall on silent re-auth).')
+      }
 
       // to get around popups requiring user gestures
       document.addEventListener('click', () => {

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -964,7 +964,7 @@ export default class TideCloak {
       // login. There is no session to silently resume after an explicit logout,
       // and the silent path is exactly where the ERR_ABORTED wedge lives.
       if (this.#consumePostLogoutMarker()) {
-        console.log('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
+        this.#logInfo('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
         await doLogin(true)
         return
       }
@@ -1110,7 +1110,6 @@ export default class TideCloak {
    * @returns {Promise<void>}
    */
   async #checkSsoSilently () {
-    console.log('[TIDE-SILENTSSO] start (timeout=' + this.silentCheckSsoTimeout + 'ms)')
     const iframe = document.createElement('iframe')
 
     return await new Promise((resolve) => {
@@ -1139,7 +1138,7 @@ export default class TideCloak {
       const settleNotAuthenticated = (via) => {
         if (settled) return
         settled = true
-        console.warn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
+        this.#logWarn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
         cleanup()
         resolve()
       }
@@ -1158,13 +1157,13 @@ export default class TideCloak {
         try {
           const oauth = this.#parseCallback(event.data)
           await this.#processCallback(oauth)
-          console.log('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
+          this.#logInfo('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
           resolve()
         } catch (error) {
           // A failed silent callback must NOT reject: rejecting would surface as
           // an init() error / AuthWall wall instead of a clean fall-through to
           // interactive login. Resolve as not-authenticated.
-          console.warn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated:', error instanceof Error ? error.message : String(error))
+          this.#logWarn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated: ' + (error instanceof Error ? error.message : String(error)))
           resolve()
         }
       }
@@ -1208,10 +1207,7 @@ export default class TideCloak {
           iframe.style.display = 'none'
           document.body.appendChild(iframe)
         })
-        .catch((error) => {
-          console.warn('[TIDE-SILENTSSO] createLoginUrl failed:', error instanceof Error ? error.message : String(error))
-          settleNotAuthenticated('createLoginUrl-error')
-        })
+        .catch(() => settleNotAuthenticated('createLoginUrl-error'))
     })
   };
 
@@ -1521,10 +1517,9 @@ export default class TideCloak {
     try {
       if (typeof window !== 'undefined' && window.localStorage) {
         window.localStorage.setItem(POST_LOGOUT_MARKER_KEY, Date.now().toString())
-        console.log('[TIDE-POSTLOGOUT] marker set in logout(); next init() will force interactive login (skip silent check-sso)')
       }
     } catch (e) {
-      console.warn('[TIDE-POSTLOGOUT] could not set marker:', e instanceof Error ? e.message : String(e))
+      this.#logWarn('[TIDE-POSTLOGOUT] could not set marker: ' + (e instanceof Error ? e.message : String(e)))
     }
     return this.#adapter.logout(options)
   }
@@ -1546,11 +1541,11 @@ export default class TideCloak {
       const ts = Number(raw)
       const fresh = Number.isFinite(ts) && (Date.now() - ts) < POST_LOGOUT_MARKER_TTL_MS
       if (!fresh) {
-        console.warn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
+        this.#logWarn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
       }
       return fresh
     } catch (e) {
-      console.warn('[TIDE-POSTLOGOUT] could not read marker:', e instanceof Error ? e.message : String(e))
+      this.#logWarn('[TIDE-POSTLOGOUT] could not read marker: ' + (e instanceof Error ? e.message : String(e)))
       return false
     }
   }

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -93,6 +93,15 @@ export default class TideCloak {
   silentCheckSsoRedirectUri
   /** @type {boolean} */
   silentCheckSsoFallback = true
+  /**
+   * Max time (ms) to wait for the hidden silent-check-sso iframe to post back
+   * before treating the attempt as "not authenticated". Guards against the
+   * post-logout wedge where the check-sso (or the Tide enclave it spins up)
+   * never responds and init() would otherwise hang forever. Overridable via
+   * initOptions.silentCheckSsoTimeout.
+   * @type {number}
+   */
+  silentCheckSsoTimeout = 10000
   /** @type {TideCloakPkceMethod} */
   pkceMethod = 'S256'
   enableLogging = false
@@ -270,6 +279,10 @@ export default class TideCloak {
 
     if (typeof initOptions.silentCheckSsoFallback === 'boolean') {
       this.silentCheckSsoFallback = initOptions.silentCheckSsoFallback
+    }
+
+    if (typeof initOptions.silentCheckSsoTimeout === 'number' && initOptions.silentCheckSsoTimeout > 0) {
+      this.silentCheckSsoTimeout = initOptions.silentCheckSsoTimeout
     }
 
     if (typeof initOptions.pkceMethod !== 'undefined') {
@@ -1068,6 +1081,16 @@ export default class TideCloak {
     document.body.appendChild(iframe)
 
     return await new Promise((resolve, reject) => {
+      let settled = false
+      /** @type {ReturnType<typeof setTimeout>=} */
+      let timer
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        window.removeEventListener('message', messageCallback)
+        if (iframe.parentNode) document.body.removeChild(iframe)
+      }
+
       /**
        * @param {MessageEvent} event
        */
@@ -1075,8 +1098,11 @@ export default class TideCloak {
         if (event.origin !== window.location.origin || iframe.contentWindow !== event.source) {
           return
         }
+        if (settled) return
+        settled = true
 
         const oauth = this.#parseCallback(event.data)
+        cleanup()
 
         try {
           await this.#processCallback(oauth)
@@ -1084,10 +1110,24 @@ export default class TideCloak {
         } catch (error) {
           reject(error)
         }
-
-        document.body.removeChild(iframe)
-        window.removeEventListener('message', messageCallback)
       }
+
+      // Fail-fast guard: a silent check-sso must NEVER hang the init() promise.
+      // After an SDK-driven logout the doken/DPoP key is flushed; if the hidden
+      // check-sso iframe (or the Tide request enclave it may spin up) never
+      // posts back, init() would otherwise never resolve, isInitializing would
+      // stay true, and the SPA would wedge on "Signing you in..." forever
+      // (observed hang: 80s+). Resolve as NOT authenticated so init() completes
+      // cleanly and the app can fall through to an interactive login (which
+      // recovers). The happy path (valid session posts back in ~1-2s) settles
+      // well before this fires, so it is unchanged.
+      timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        this.#logWarn('[TIDECLOAK] Silent check-sso timed out after ' + this.silentCheckSsoTimeout + 'ms; treating as unauthenticated so the app can fall through to interactive login.')
+        cleanup()
+        resolve()
+      }, this.silentCheckSsoTimeout)
 
       window.addEventListener('message', messageCallback)
     })
@@ -1800,6 +1840,38 @@ export default class TideCloak {
   }
 
   /**
+   * Trigger a full interactive login redirect. Used as the recovery leg when a
+   * silent flow cannot proceed (e.g. the enclave asks for a doken refresh but
+   * the doken was flushed at logout). Navigates the whole page to Keycloak.
+   * @returns {Promise<void>}
+   */
+  async #reloginInteractively () {
+    await this.login({
+      idpHint: 'tide',
+      prompt: 'login',
+      redirectUri: window.location.href
+    })
+  }
+
+  /**
+   * Provide the current doken to the enclave, or fall through to interactive
+   * login when there is none (post-logout / flushed state). Throwing a bare
+   * error here would leave the enclave (and whatever awaits its doken-refresh
+   * completion) hanging; instead we redirect to a full interactive login, which
+   * recovers cleanly.
+   * @returns {Promise<string>}
+   */
+  async #provideDokenOrRelogin () {
+    await this.ensureTokenReady()
+    if (!this.doken) {
+      this.#logWarn('[TIDECLOAK] Enclave requested a doken refresh but no doken is present (post-logout). Falling through to interactive login.')
+      await this.#reloginInteractively()
+      throw new Error('[TIDECLOAK] No doken found - redirecting to interactive login')
+    }
+    return this.doken
+  }
+
+  /**
    * Initialize Tide RequestEnclave.
    */
   initRequestEnclave () {
@@ -1815,18 +1887,8 @@ export default class TideCloak {
         isRunningLocal: new URL(this.#getVoucherUrl()).hostname === "localhost"
       }).init({
         doken: this.doken,
-        dokenRefreshCallback: async () => {
-          await this.ensureTokenReady()
-          if (!this.doken) throw new Error('[TIDECLOAK] No doken found')
-          return this.doken
-        },
-        requireReloginCallback: async () => {
-          await this.login({
-            idpHint: 'tide',
-            prompt: 'login',
-            redirectUri: window.location.href
-          })
-        }
+        dokenRefreshCallback: async () => this.#provideDokenOrRelogin(),
+        requireReloginCallback: async () => this.#reloginInteractively()
       })
     }
   }
@@ -1848,18 +1910,8 @@ export default class TideCloak {
         backgroundUrl: this.#config['backgroundUrl'],
         logoUrl: this.#config['logoUrl'],
         doken: this.doken,
-        dokenRefreshCallback: async () => {
-          await this.ensureTokenReady()
-          if (!this.doken) throw new Error('[TIDECLOAK] No doken found')
-          return this.doken
-        },
-        requireReloginCallback: async () => {
-          await this.login({
-            idpHint: 'tide',
-            prompt: 'login',
-            redirectUri: window.location.href
-          })
-        }
+        dokenRefreshCallback: async () => this.#provideDokenOrRelogin(),
+        requireReloginCallback: async () => this.#reloginInteractively()
       })
     }
   }


### PR DESCRIPTION
## Problem

`login -> logout -> login` wedges the SPA on "Signing you in..." (QA-confirmed). After an SDK logout, the Tide `RequestEnclave` (heimdall) is **not** torn down (logout only `#dpopProvider.flush()`). On token-clear, `#setToken`'s no-doken branch calls `requestEnclave.updateDoken(undefined)`, which sends the hidden enclave a `doken refresh` with no doken; the enclave throws `TIDE-SWE-UNHANDLED Expecting doken in request` and the SPA hangs. It never reaches the ORK. A full interactive re-login recovers (fresh doken re-creates the enclave), so only the silent-refresh-after-logout path is broken.

This is the client-side face of the silent-SSO DPoP bug; the staging face (a client force-minting the empty approval to `/token` -> ORK 500) is hardened separately in `ork#391`.

## Fix (SDK-only)

- `#setToken` no-doken branch: replace `requestEnclave.updateDoken(undefined)` with a new `#teardownEnclaves()` that `close()`s and nulls `requestEnclave` + `approvalEnclave`. No dokenless refresh is ever sent; the surviving `document.click` listener can't reopen a dokenless enclave; the next authenticated flow re-creates a fresh enclave from a valid doken -> app falls through to interactive login (which QA proved recovers).
- `#ensureRequestEnclaveOpen()`: defensive guard `|| !this.doken`.
- Happy path (valid doken) unchanged.

No enclave-bundle change needed , we simply never send the doomed refresh.

## Verify

`tsc -p tsconfig.esm.json` , exit 0. Live `login->logout->login` repro on local realm `tideqa-dpopqa` to follow (rebuild into the tide-console).

## Consumers

Branch is off `add-dpop-signing` (keylessh's SDK source) so merging covers keylessh. The tide-console bundles published `@tidecloak/js@0.13.27`; it will pick up the fix on the next `@tidecloak/js` publish.