### PR TITLE
fix(sdk): derive silent-check-sso redirect URI from the app base, never origin-root

### DIFF
--- a/packages/tidecloak-js/package.json
+++ b/packages/tidecloak-js/package.json
@@ -24,6 +24,7 @@
     "./policy.css": "./dist/esm/src/policy.css"
   },
   "scripts": {
+    "test": "node --test test/*.test.js",
     "postinstall": "node ./scripts/postinstall.cjs",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/packages/tidecloak-js/src/IAMService.js
+++ b/packages/tidecloak-js/src/IAMService.js
@@ -1,4 +1,4 @@
-import { makePkce, fetchJson } from "./utils/index.js";
+import { makePkce, fetchJson, resolveSilentCheckSsoRedirectUri } from "./utils/index.js";
 import TideCloak, { RequestEnclave } from "../lib/tidecloak.js";
 
 /**
@@ -490,13 +490,77 @@ class IAMService {
       return !!this._tc.tokenParsed;
     }
 
+    // Read an init option from the resolved config. `loadConfig` assigns
+    // `this._config = config`, so these are normally the same object; we check
+    // both so a caller that passes options only to `initIAM` is still honoured.
+    const pick = (key) => this._config?.[key] ?? config?.[key];
+
+    // --- Silent-check-SSO redirect URI ---------------------------------------
+    // This used to be hardcoded to `${window.location.origin}/silent-check-sso.html`
+    // with NO caller override, which is only correct for an origin-root-hosted
+    // app. Any app served under a sub-path got a URI that is neither served nor
+    // registered on the OIDC client, so Keycloak answered `400 Invalid parameter:
+    // redirect_uri`, the silent iframe never posted back, and the app hung on its
+    // bootstrap spinner. Resolve it properly instead: an explicit caller value
+    // always wins, otherwise derive from the app's declared base. See
+    // ./utils/silentCheckSso.js.
+    const hasBaseElement =
+      typeof document !== "undefined" && !!document.querySelector("base[href]");
+    const silentSso = resolveSilentCheckSsoRedirectUri({
+      origin: window.location.origin,
+      configured: pick("silentCheckSsoRedirectUri"),
+      // `document.baseURI` is the browser's resolution of `<base href>`. Only pass
+      // it when such an element actually exists - otherwise it is just the current
+      // page URL, which for a deep SPA route would derive a bogus base.
+      baseHref: hasBaseElement ? document.baseURI : undefined,
+      redirectUri: pick("redirectUri"),
+    });
+
+    if (!silentSso.uri) {
+      // FAIL LOUD. Passing `undefined` makes TideCloak skip the silent check
+      // entirely and fall back to a redirect-based `prompt=none` login, which
+      // still authenticates the user. That is strictly better than emitting a
+      // URI we know will 400 and wedge the app on its spinner.
+      console.error(
+        `[IAMService] Cannot derive a silent-check-sso redirect URI: ${silentSso.reason}. ` +
+          "Skipping silent check-sso and falling back to a redirect-based login. " +
+          "Set `silentCheckSsoRedirectUri` in your TideCloak config to a URI that is " +
+          "both served by your app and registered on the OIDC client."
+      );
+    } else if (silentSso.source !== "config") {
+      console.debug(
+        `[IAMService] silentCheckSsoRedirectUri derived from ${silentSso.source}: ${silentSso.uri}`
+      );
+    }
+
+    const redirectUri = pick("redirectUri");
+    const silentCheckSsoFallback = pick("silentCheckSsoFallback");
+    const silentCheckSsoTimeout = pick("silentCheckSsoTimeout");
+    const scope = pick("scope");
+
     let authenticated = false;
     try {
       authenticated = await this._tc.init({
         setupRequestEnclave: config.setupRequestEnclave ?? true, // true by default because most clients that uses this will need it on
+        // NOTE: `onLoad` is deliberately NOT taken from the caller's config here.
+        // Callers (e.g. the admin console) pass `onLoad: "login-required"`, and
+        // honouring it would send #processInit down the `login-required` branch,
+        // which does a full top-level redirect on every load and never runs the
+        // silent check-sso path at all. That is a separate product decision, not
+        // part of fixing the redirect URI. Changing it belongs in its own change.
         onLoad: "check-sso",
-        silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
-        pkceMethod: "S256",
+        // `undefined` => TideCloak skips silent check-sso (see #processInit) and
+        // falls back to an interactive login rather than emitting a bad URI.
+        silentCheckSsoRedirectUri: silentSso.uri,
+        pkceMethod: pick("pkceMethod") ?? "S256",
+        // Forward the rest of the caller's init options instead of dropping them
+        // on the floor. `redirectUri` in particular must reach the TideCloak
+        // instance for sub-path-hosted apps, otherwise the adapter falls back to
+        // `location.href`.
+        ...(redirectUri !== undefined && { redirectUri }),
+        ...(silentCheckSsoFallback !== undefined && { silentCheckSsoFallback }),
+        ...(silentCheckSsoTimeout !== undefined && { silentCheckSsoTimeout }),
+        ...(scope !== undefined && { scope }),
         ...(this._config?.useDPoP && { useDPoP: this._config.useDPoP }),
         ...(this._config?.checkLoginIframe === false && { checkLoginIframe: false }),
       });

--- a/packages/tidecloak-js/src/utils/index.js
+++ b/packages/tidecloak-js/src/utils/index.js
@@ -1,2 +1,3 @@
 export { makePkce, randomPkceVerifier, base64UrlEncode } from './pkce.js';
 export { fetchJson } from './fetch.js';
+export { resolveSilentCheckSsoRedirectUri, SILENT_CHECK_SSO_FILENAME } from './silentCheckSso.js';

--- a/packages/tidecloak-js/src/utils/silentCheckSso.js
+++ b/packages/tidecloak-js/src/utils/silentCheckSso.js
@@ -1,0 +1,143 @@
+/**
+ * Resolution of the silent-check-SSO redirect URI.
+ *
+ * ## Why this exists
+ *
+ * `IAMService.initIAM` used to hardcode:
+ *
+ * ```js
+ * silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`
+ * ```
+ *
+ * That is only correct for an app served from the ORIGIN ROOT. For any app
+ * hosted under a sub-path (e.g. a console served at
+ * `https://host/realms/<realm>/tide-console/`) the origin-root URI is:
+ *
+ *   - NOT served (there is no file at `/silent-check-sso.html`), and
+ *   - NOT a registered `redirectUri` on the OIDC client,
+ *
+ * so the authorization request fails with `400 Invalid parameter: redirect_uri`.
+ * The silent iframe then never posts back and the app hangs on its bootstrap
+ * spinner. A silently-wrong URI is the worst possible outcome, so this module
+ * either derives a CORRECT base-aware URI or reports that it cannot, letting
+ * the caller fail loud and fall back to a redirect-based login.
+ *
+ * ## Resolution order
+ *
+ * 1. **Caller-supplied `silentCheckSsoRedirectUri`** - always wins, verbatim.
+ * 2. **`<base href>`** - the standard way a sub-path-hosted SPA declares where
+ *    it lives. Resolved via the browser's own `document.baseURI`.
+ * 3. **The app's configured OIDC `redirectUri`** - the SDK already requires this
+ *    to be base-aware and registered, so it is a sound source of truth for the
+ *    app's base. The SDK's own convention is `<base>auth/redirect`, which is
+ *    stripped to recover `<base>` exactly; any other redirect path is resolved
+ *    relative to its own directory.
+ * 4. **Origin root** - only when the app declares NEITHER a base NOR a
+ *    redirectUri. Such an app is relying on the SDK's origin-root default
+ *    redirectUri (`${origin}/auth/redirect`) and is therefore root-hosted by
+ *    construction. This preserves the historical behaviour for every existing
+ *    root-hosted consumer.
+ *
+ * Anything that cannot be resolved (cross-origin or malformed redirectUri)
+ * returns `uri: undefined` plus a `reason`, so the caller can log an error and
+ * SKIP the silent check rather than emit a URI that will 400.
+ */
+
+/** Filename the SDK ships and that hosting providers are expected to serve. */
+export const SILENT_CHECK_SSO_FILENAME = 'silent-check-sso.html';
+
+/** The redirect path convention IAMService itself defaults to (`<base>auth/redirect`). */
+const AUTH_REDIRECT_SUFFIX = 'auth/redirect';
+
+/**
+ * @typedef {object} SilentCheckSsoResolution
+ * @property {string|undefined} uri    The resolved URI, or undefined if none could be derived.
+ * @property {'config'|'base-href'|'redirect-uri-convention'|'redirect-uri'|'origin-root'|'none'} source
+ * @property {string} [reason]         Why resolution failed (only when `uri` is undefined).
+ */
+
+/**
+ * Resolve the silent-check-SSO redirect URI.
+ *
+ * Pure: every environment input is passed in explicitly, so this is unit-testable
+ * with no DOM. See the module docblock for the resolution order.
+ *
+ * @param {object} params
+ * @param {string} params.origin        The app's origin (`window.location.origin`).
+ * @param {string} [params.configured]  Caller-supplied `silentCheckSsoRedirectUri`.
+ * @param {string} [params.baseHref]    `document.baseURI`, but ONLY when a `<base href>` element exists.
+ * @param {string} [params.redirectUri] Caller-supplied OIDC `redirectUri`.
+ * @returns {SilentCheckSsoResolution}
+ */
+export function resolveSilentCheckSsoRedirectUri ({ origin, configured, baseHref, redirectUri } = {}) {
+  // 1. An explicit value ALWAYS wins, on every init path. Dropping it is the bug
+  //    that took the sub-path-hosted console down.
+  if (isNonEmptyString(configured)) {
+    return { uri: configured.trim(), source: 'config' };
+  }
+
+  if (!isNonEmptyString(origin)) {
+    return { uri: undefined, source: 'none', reason: 'no origin available (non-browser context)' };
+  }
+
+  // 2. A declared <base href> is the app telling us exactly where it is hosted.
+  if (isNonEmptyString(baseHref)) {
+    try {
+      const base = new URL(baseHref, origin);
+      return { uri: new URL(SILENT_CHECK_SSO_FILENAME, base).href, source: 'base-href' };
+    } catch {
+      // Malformed <base href> - fall through to the redirectUri, which is more
+      // load-bearing anyway (login is already broken if it is wrong).
+    }
+  }
+
+  // 3. Derive the base from the app's own configured OIDC redirectUri.
+  if (isNonEmptyString(redirectUri)) {
+    let parsed;
+    try {
+      parsed = new URL(redirectUri, origin);
+    } catch {
+      return {
+        uri: undefined,
+        source: 'none',
+        reason: `configured redirectUri (${redirectUri}) is not a valid URL, so the app base cannot be derived`
+      };
+    }
+
+    if (parsed.origin !== origin) {
+      return {
+        uri: undefined,
+        source: 'none',
+        reason: `configured redirectUri (${redirectUri}) is on a different origin than the app (${origin}), so the app base cannot be derived`
+      };
+    }
+
+    // The SDK's own convention: `<base>auth/redirect`. Strip the suffix to
+    // recover `<base>` (keeping its trailing slash) rather than resolving
+    // relative to `<base>auth/`, which would be one directory too deep.
+    if (parsed.pathname.endsWith(`/${AUTH_REDIRECT_SUFFIX}`)) {
+      const basePath = parsed.pathname.slice(0, parsed.pathname.length - AUTH_REDIRECT_SUFFIX.length);
+      return {
+        uri: new URL(SILENT_CHECK_SSO_FILENAME, new URL(basePath, origin)).href,
+        source: 'redirect-uri-convention'
+      };
+    }
+
+    // Any other redirect path: resolve the filename against the redirect URI's
+    // own directory (`/app/callback` -> `/app/silent-check-sso.html`).
+    return { uri: new URL(SILENT_CHECK_SSO_FILENAME, parsed).href, source: 'redirect-uri' };
+  }
+
+  // 4. Neither a base nor a redirectUri was declared. The app is therefore
+  //    relying on the SDK's origin-root default redirectUri, i.e. it is
+  //    root-hosted, and origin-root is the right answer.
+  return { uri: `${origin}/${SILENT_CHECK_SSO_FILENAME}`, source: 'origin-root' };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isNonEmptyString (value) {
+  return typeof value === 'string' && value.trim() !== '';
+}

--- a/packages/tidecloak-js/test/silentCheckSso.test.js
+++ b/packages/tidecloak-js/test/silentCheckSso.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for the silent-check-SSO redirect URI resolver.
+ *
+ * Run with: npm test  (uses node:test - no external dependencies)
+ *
+ * The regression these lock down: a sub-path-hosted app (e.g. a console served
+ * at `https://host/realms/<realm>/tide-console/`) used to get the hardcoded
+ * origin-root URI `https://host/silent-check-sso.html`, which is neither served
+ * nor a registered redirectUri -> `400 Invalid parameter: redirect_uri` -> the
+ * silent iframe never posts back -> the app hangs on its bootstrap spinner.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveSilentCheckSsoRedirectUri,
+  SILENT_CHECK_SSO_FILENAME
+} from '../src/utils/silentCheckSso.js';
+
+const ORIGIN = 'https://staging.dauth.me';
+const CONSOLE_BASE = '/realms/myrealm/tide-console/';
+
+test('an explicit caller-supplied URI always wins', () => {
+  const explicit = `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`;
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    configured: explicit,
+    // Even with competing signals present, the explicit value must be used verbatim.
+    baseHref: `${ORIGIN}/somewhere-else/`,
+    redirectUri: `${ORIGIN}/other/auth/redirect`
+  });
+
+  assert.equal(result.uri, explicit);
+  assert.equal(result.source, 'config');
+});
+
+test('an explicit URI survives even when it is the only thing supplied', () => {
+  const explicit = `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`;
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN, configured: explicit });
+
+  assert.equal(result.uri, explicit);
+  assert.equal(result.source, 'config');
+});
+
+test('derives a base-aware URI from a declared <base href>', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: `${ORIGIN}${CONSOLE_BASE}`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('derives the app base from the SDK `<base>auth/redirect` convention', () => {
+  // This is the exact shape a sub-path-hosted console configures.
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}${CONSOLE_BASE}auth/redirect`
+  });
+
+  // Must be `<base>/silent-check-sso.html`, NOT `<base>/auth/silent-check-sso.html`
+  // (one directory too deep) and NOT the origin root.
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri-convention');
+});
+
+test('the sub-path case never falls back to origin-root (the outage)', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}${CONSOLE_BASE}auth/redirect`
+  });
+
+  assert.notEqual(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+});
+
+test('derives from a non-conventional redirect path via its own directory', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/app/callback`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/app/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri');
+});
+
+test('BACK-COMPAT: a root-hosted app with the default redirectUri still gets origin-root', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/auth/redirect` // the SDK's own origin-root default
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri-convention');
+});
+
+test('BACK-COMPAT: an app declaring nothing at all still gets origin-root', () => {
+  // Every existing root-hosted consumer that configures neither a base nor a
+  // redirectUri must keep working exactly as before.
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'origin-root');
+});
+
+test('a root-level callback resolves to origin-root', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/callback`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+});
+
+test('<base href> takes precedence over redirectUri', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: `${ORIGIN}${CONSOLE_BASE}`,
+    redirectUri: `${ORIGIN}/elsewhere/auth/redirect`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('a relative <base href> resolves against the origin', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: CONSOLE_BASE
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('FAILS LOUD on a cross-origin redirectUri rather than guessing', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: 'https://evil.example.com/app/auth/redirect'
+  });
+
+  assert.equal(result.uri, undefined);
+  assert.equal(result.source, 'none');
+  assert.match(result.reason, /different origin/);
+});
+
+test('FAILS LOUD when there is no origin (non-browser context)', () => {
+  const result = resolveSilentCheckSsoRedirectUri({});
+
+  assert.equal(result.uri, undefined);
+  assert.equal(result.source, 'none');
+});
+
+test('an empty-string config value is not treated as supplied', () => {
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN, configured: '   ' });
+
+  // Falls through to origin-root rather than emitting an empty redirect_uri.
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'origin-root');
+});


### PR DESCRIPTION
## Problem

The custom Tide admin console wedges on **"Signing you in..."** after login + refresh, with a **400 `Invalid parameter: redirect_uri`** on its silent check-sso. Reproduced live on staging (`sasha-02`, `sasha-test02`).

The console is hosted at a **realm sub-path**: `https://staging.dauth.me/realms/{realm}/tide-console/`. Its silent check-sso must redirect to `.../realms/{realm}/tide-console/silent-check-sso.html` - which **is** served (200) and **is** what provisioning registers.

Instead the SDK emitted:

```
redirect_uri=https://staging.dauth.me/silent-check-sso.html      <-- ORIGIN-ROOT
```

neither served (404) nor registered (400).

## Root cause

`IAMService.initIAM` (`src/IAMService.js:479-487`) built the TideCloak init options as a **whitelist, not a merge**:

```js
authenticated = await this._tc.init({
  setupRequestEnclave: config.setupRequestEnclave ?? true,
  onLoad: "check-sso",
  silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,  // hardcoded
  pkceMethod: "S256",
  ...(this._config?.useDPoP && { useDPoP: this._config.useDPoP }),           // only these two
  ...(this._config?.checkLoginIframe === false && { checkLoginIframe: false }),
});
```

There is **no config spread**. A caller-supplied `silentCheckSsoRedirectUri` is not overridden - it is **never read at all**. Origin-root won because it was the only value ever passed.

The app-supplied URI reaches `IAMService` fully intact and is discarded at the last step:

| # | Location | Status |
|---|---|---|
| 1 | tide-admin-ui `lib/env.ts` - base-aware getter | correct |
| 2-3 | `TideAuthProvider` - passed as prop into `providerConfig` | correct |
| 4 | `tidecloak-react` `TideCloakContextProvider` - survives `finalConfig` | correct |
| 5 | `IAMService.js:194` - `this._config = config`, value present | correct |
| 6 | **`IAMService.js:479`** - **whitelist drops it** | **ROOT CAUSE** |

The `TideCloak` class was never broken (`lib/tidecloak.js:285-287` honors `initOptions.silentCheckSsoRedirectUri` correctly). `IAMService` is the single leaky path. The failure mode is a **silent** hard wedge rather than a visible error, which is what made this expensive to diagnose.

## Fix

**`src/utils/silentCheckSso.js` (new)** - pure, DOM-free `resolveSilentCheckSsoRedirectUri({origin, configured, baseHref, redirectUri})`. Precedence:

1. caller-supplied value wins verbatim
2. `<base href>`
3. the app's OIDC `redirectUri` (recovers the base from the SDK's own `<base>auth/redirect` convention)
4. origin-root **only** when the app declares neither a base nor a redirectUri - i.e. it is root-hosted by construction

Underivable cases (cross-origin / malformed) return `undefined` + a `reason`.

**`src/IAMService.js`** - calls the resolver; on `undefined` logs `console.error` and passes `undefined`, which makes TideCloak **skip silent check-sso and fall back to a redirect login** (fail loud, never silently emit a URI that 400s). Also stops dropping `redirectUri`, `silentCheckSsoFallback`, `silentCheckSsoTimeout`, `scope`, `pkceMethod`.

No tide-console-specific logic - works for any sub-path-hosted consumer. Every newly-forwarded option is inert unless the caller sets it, so no existing consumer changes behavior.

## Risk to the existing silent-SSO hardening: none

`lib/tidecloak.js` is **not in the diff** - the post-logout marker, bulletproof `#checkSsoSilently` settle funnel, and deferred enclave pre-warm (PR #90, already merged to main) are untouched. The fail-loud `undefined` path routes into the **pre-existing** `this.silentCheckSsoRedirectUri ? #checkSsoSilently() : doLogin(false)` branch, and `undefined` is already a supported state (`#check3pCookiesSupported` sets it itself when 3rd-party cookies are blocked).

## Deliberate scope boundary - `onLoad`

This PR does **not** forward `onLoad`. The console passes `onLoad: 'login-required'`; main currently swallows it (which is *why* the console runs `check-sso` and hits the silent path at all). Honoring it would send `#processInit` down the `login-required` branch - a full top-level redirect on every load that never runs silent check-sso, bypassing the very path we are fixing. That is a product decision, not part of this bug.

Note `d05e79e` on `add-dpop-signing` *does* honor `onLoad`. **If that branch merges with main, expect a conflict in this block and re-decide `onLoad` explicitly.**

## Companion fix (both halves required)

This makes the SDK **request** the correct URI. The companion makes it **registered**:
tide-foundation/tidecloak-idp-extensions#61 - closes a backfill gap where `setupTideAdminConsole` never added redirect URIs to already-existing `tide-admin-console` clients.

After deploying that jar, the operator must re-run `POST {vendor}/sign-idp-settings` once per affected realm.

**tide-admin-ui needs no change** - it already passes a correct base-aware value; it just needs rebuilding against the fixed SDK.

## Testing

- **14 new unit tests, all passing** - `test/silentCheckSso.test.js`, using built-in `node:test` (**no new deps**; the repo had no test runner). Covers the outage case, both root-hosted back-compat cases, `<base href>` precedence, and fail-loud.
- Root cause verified end-to-end against the live staging deployment.

## Related bug found (NOT fixed here)

Same class, still open: `tidecloak-react/src/contexts/TideCloakContextProvider.tsx:151` defaults `configUrl = '/adapter.json'` - origin-root, so it breaks any sub-path-hosted app that relies on the fetch path. The console dodged it by passing `config` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)