### PR TITLE
Release 0.14.0

### DIFF
--- a/packages/tidecloak-create-nextjs/package.json
+++ b/packages/tidecloak-create-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidecloak/create-nextjs",
-  "version": "0.12.15",
+  "version": "0.14.0",
   "type": "module",
   "description": "Scaffold a TideCloak-ready Next.js app with optional IAM setup and working auth - start building instantly with a live example",
   "bin": {

--- a/packages/tidecloak-create-nextjs/template-js-app/package.json
+++ b/packages/tidecloak-create-nextjs/template-js-app/package.json
@@ -12,6 +12,6 @@
     "next": "16.x",
     "react": "19.x",
     "react-dom": "19.x",
-    "@tidecloak/nextjs": "^0.13.11"
+    "@tidecloak/nextjs": "^0.14.0"
   }
 }

--- a/packages/tidecloak-create-nextjs/template-ts-app/package.json
+++ b/packages/tidecloak-create-nextjs/template-ts-app/package.json
@@ -12,7 +12,7 @@
     "next": "16.x",
     "react": "19.x",
     "react-dom": "19.x",
-    "@tidecloak/nextjs": "^0.13.11"
+    "@tidecloak/nextjs": "^0.14.0"
   },
   "devDependencies": {
     "@types/node": "24.0.13",

--- a/packages/tidecloak-js/docs/FRONT_CHANNEL.md
+++ b/packages/tidecloak-js/docs/FRONT_CHANNEL.md
@@ -80,14 +80,14 @@ await IAMService.initIAM({
 
 **Offline mode** lets users access your app even when their session has expired. You can then prompt for re-login only when an API call fails with 401.
 
-### DPoP (on by default)
+### DPoP (opt-in)
 
-DPoP (sender-constrained tokens, [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)) is **enabled and enforced by default** in all TideCloak SDKs — you don't need to configure anything. The SDK binds tokens to a per-session key so a stolen bearer token can't be replayed.
+DPoP (sender-constrained tokens, [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)) binds an access token to a per-session key, so a stolen token can't be replayed. It is **opt-in**: set `useDPoP` and the SDK turns it on; omit it and the SDK requests an ordinary (unbound) token.
 
-By default it runs in **`strict`** mode: if the realm doesn't advertise DPoP support, `initIAM` fails fast rather than silently downgrading to plain bearer tokens. You can change this:
+> **DPoP is not a flag you can flip in isolation.** Asking for it appends `dpop_jkt` to the authorization request, and the realm then issues a token carrying `typ: "DPoP"` and `cnf.jkt`. Such a token is **invalid** if it is later presented as a plain `Authorization: Bearer …` — the resource server answers a bare `401`. So enable DPoP only if every call that carries the token attaches a `DPoP:` proof (use `IAMService.secureFetch`, which does this for you). This is why the SDK will not turn DPoP on for you.
 
 ```js
-// Default (no config needed) — equivalent to:
+// Opt in, enforced — init fails if the realm doesn't advertise DPoP support:
 await IAMService.initIAM({ ...config, useDPoP: { mode: "strict" } });
 
 // Use DPoP only when the realm supports it, otherwise fall back to bearer:
@@ -96,16 +96,16 @@ await IAMService.initIAM({ ...config, useDPoP: { mode: "auto" } });
 // Pick the proof signing algorithm (default "ES256"):
 await IAMService.initIAM({ ...config, useDPoP: { mode: "strict", alg: "EdDSA" } });
 
-// Disable DPoP entirely:
-await IAMService.initIAM({ ...config, useDPoP: false });
+// No DPoP — a plain, unbound access token (the default):
+await IAMService.initIAM({ ...config });
 ```
 
 | `useDPoP` value            | Behavior                                                                 |
 | -------------------------- | ------------------------------------------------------------------------ |
-| *(omitted)* / `true`       | **Default.** DPoP enforced (`strict`); init fails if the realm lacks DPoP support. |
+| *(omitted)* / `false`      | **Default.** No DPoP. No `dpop_jkt`, plain unbound access token.          |
 | `{ mode: "auto" }`         | Use DPoP when the realm advertises it; otherwise fall back to bearer.    |
-| `{ mode: "strict", alg }`  | Enforce DPoP with a specific proof algorithm (`ES256` default).          |
-| `false`                    | Disable DPoP.                                                            |
+| `{ mode: "strict" }`       | Enforce DPoP; init fails if the realm lacks DPoP support.                |
+| `{ mode: …, alg }`         | As above, with a specific proof algorithm (`ES256` default).            |
 
 > Your **resource server** must validate DPoP proofs for the binding to be meaningful. See [`lib/README.md`](../lib/README.md#dpop-resource-server-setup) for serving `tide_dpop_auth.html`.
 

--- a/packages/tidecloak-js/lib/secureFetchPolicy.js
+++ b/packages/tidecloak-js/lib/secureFetchPolicy.js
@@ -1,0 +1,41 @@
+/**
+ * The decision seam of `TideCloak.secureFetch`: given the caller's `Authorization`
+ * header (if any) and the access token this client currently holds, should we sign
+ * the request as our own - `Authorization: DPoP <token>` plus a `DPoP:` proof?
+ *
+ * Kept in its own dependency-free module so it can be unit-tested directly.
+ * `lib/tidecloak.js` pulls in `heimdall-tide`, which cannot be loaded under plain
+ * node ESM, so the predicate is unreachable from a test if it lives there - and
+ * this is precisely the seam where a mistake becomes an unexplainable `401`.
+ */
+
+/**
+ * @param {string|null|undefined} existingAuth - the caller's `Authorization` header.
+ * @param {string} ourToken - the access token this client currently holds.
+ * @returns {boolean} true -> attach `Authorization: DPoP <ourToken>` + a DPoP proof.
+ *
+ * Three cases:
+ *
+ *  - NO `Authorization` header: YES, attach. "I set no Authorization, use your
+ *    token" is the entire point of calling `secureFetch` rather than `fetch`, and
+ *    it is exactly what `secureFetch`'s own stale-token warning tells callers to do
+ *    ("omit the Authorization header entirely and let secureFetch attach it").
+ *
+ *    This case used to be false, which sent the request as a plain, UNAUTHENTICATED
+ *    fetch: no token, no proof, no credentials of any kind. A consumer that reads
+ *    its token from an async state container and calls before that state has
+ *    settled (React state that has not yet committed, say) would silently ship a
+ *    credential-less admin request and get back a bare `401` naming none of this.
+ *    That is the admin-API 401 this closes.
+ *
+ *  - OUR bearer token: YES, attach - upgrade `Bearer` to `DPoP` + proof. Unchanged.
+ *
+ *  - SOMEONE ELSE'S bearer token: NO. A third-party API call is a legitimate
+ *    pass-through: it goes out verbatim and must never be handed one of our proofs.
+ *    Unchanged. (A stale copy of one of ours lands here too, and is warned about
+ *    once by the caller.)
+ */
+export function shouldAttachDpopProof (existingAuth, ourToken) {
+  if (existingAuth === null || existingAuth === undefined) return true
+  return existingAuth === `Bearer ${ourToken}`
+}

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -341,9 +341,29 @@ export default class TideCloak {
 
     this.onReady?.(this.authenticated)
 
-    // initialize request enclave if authenticated
-    if(this.doken && initOptions.setupRequestEnclave) {
-      this.initRequestEnclave();
+    // Do NOT eagerly open the Tide RequestEnclave during init().
+    //
+    // On a post-logout silent re-auth, the doken returned by the silent
+    // check-sso can be STALE: its session key no longer matches the session the
+    // hidden enclave cached from the previous login. Opening the hidden enclave
+    // here makes it sit "waiting for doken refresh" forever - a refresh that
+    // never comes because no fresh doken exists - which is exactly the
+    // "[ENCLAVE] Received init but waiting for doken refresh" ... hang that
+    // wedges the SPA on "Signing you in..." on the second login. (The enclave
+    // silently WAITS rather than emitting an error, so heimdall's own
+    // requireReloginCallback recovery never fires.)
+    //
+    // Instead we DEFER enclave setup: it is created lazily on the first real
+    // Tide operation (encrypt / decrypt / approve / signDpopApproval - each
+    // calls initRequestEnclave()), by which point a fresh interactive login has
+    // minted a current doken and the enclave can complete its handshake. We
+    // still register the user-gesture listener so the popup fallback can open
+    // once an enclave has actually been created; #ensureRequestEnclaveOpen
+    // no-ops while there is no enclave or no doken.
+    if (initOptions.setupRequestEnclave) {
+      if (this.doken) {
+        this.#logInfo('[TIDECLOAK] Deferring Tide RequestEnclave setup until first use (not opening during init to avoid a stale-doken handshake stall on silent re-auth).')
+      }
 
       // to get around popups requiring user gestures
       document.addEventListener('click', () => {

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -1861,6 +1861,36 @@ export default class TideCloak {
       }
       return resp
     } else {
+      // SAFETY INVARIANT: if a DPoP provider exists, this client's tokens are
+      // sender-constrained (`cnf.jkt`), and a DPoP-bound token presented as a
+      // plain `Bearer` is INVALID per RFC 9449 - the resource server answers a
+      // bare `401` that names none of this. The silent fallback below is what
+      // hid exactly that bug. So when we are about to drop out of the DPoP path
+      // while STILL carrying an Authorization header, say so loudly - once per
+      // distinct header value, so a wedged consumer gets a signal rather than a
+      // scrolling wall.
+      if (dpopProvider) {
+        const existingAuth = new Headers(init.headers).get('Authorization')
+        if (
+          typeof existingAuth === 'string' &&
+          existingAuth.startsWith('Bearer ') &&
+          existingAuth !== this.#warnedStaleBearer
+        ) {
+          this.#warnedStaleBearer = existingAuth
+          console.error(
+            '[TIDECLOAK] secureFetch: DPoP is ENABLED on this client, but the request is going out as a ' +
+            'plain `Authorization: Bearer …` with NO DPoP proof' +
+            (!this.authenticated
+              ? ' (the client is not authenticated yet)'
+              : !this.token
+                ? ' (the client holds no access token yet)'
+                : '') +
+            '. If that token is DPoP-bound (`cnf.jkt`), the server will reject it with a bare 401. ' +
+            'Wait for the SDK to be authenticated and read the token from it at call time, or turn DPoP ' +
+            'off for this flow (omit `useDPoP` from the config).'
+          )
+        }
+      }
       return fetch(url, init)
     }
   }

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -963,7 +963,7 @@ export default class TideCloak {
       // login. There is no session to silently resume after an explicit logout,
       // and the silent path is exactly where the ERR_ABORTED wedge lives.
       if (this.#consumePostLogoutMarker()) {
-        console.log('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
+        this.#logInfo('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
         await doLogin(true)
         return
       }
@@ -1109,7 +1109,6 @@ export default class TideCloak {
    * @returns {Promise<void>}
    */
   async #checkSsoSilently () {
-    console.log('[TIDE-SILENTSSO] start (timeout=' + this.silentCheckSsoTimeout + 'ms)')
     const iframe = document.createElement('iframe')
 
     return await new Promise((resolve) => {
@@ -1138,7 +1137,7 @@ export default class TideCloak {
       const settleNotAuthenticated = (via) => {
         if (settled) return
         settled = true
-        console.warn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
+        this.#logWarn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
         cleanup()
         resolve()
       }
@@ -1157,13 +1156,13 @@ export default class TideCloak {
         try {
           const oauth = this.#parseCallback(event.data)
           await this.#processCallback(oauth)
-          console.log('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
+          this.#logInfo('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
           resolve()
         } catch (error) {
           // A failed silent callback must NOT reject: rejecting would surface as
           // an init() error / AuthWall wall instead of a clean fall-through to
           // interactive login. Resolve as not-authenticated.
-          console.warn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated:', error instanceof Error ? error.message : String(error))
+          this.#logWarn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated: ' + (error instanceof Error ? error.message : String(error)))
           resolve()
         }
       }
@@ -1207,10 +1206,7 @@ export default class TideCloak {
           iframe.style.display = 'none'
           document.body.appendChild(iframe)
         })
-        .catch((error) => {
-          console.warn('[TIDE-SILENTSSO] createLoginUrl failed:', error instanceof Error ? error.message : String(error))
-          settleNotAuthenticated('createLoginUrl-error')
-        })
+        .catch(() => settleNotAuthenticated('createLoginUrl-error'))
     })
   };
 
@@ -1520,10 +1516,9 @@ export default class TideCloak {
     try {
       if (typeof window !== 'undefined' && window.localStorage) {
         window.localStorage.setItem(POST_LOGOUT_MARKER_KEY, Date.now().toString())
-        console.log('[TIDE-POSTLOGOUT] marker set in logout(); next init() will force interactive login (skip silent check-sso)')
       }
     } catch (e) {
-      console.warn('[TIDE-POSTLOGOUT] could not set marker:', e instanceof Error ? e.message : String(e))
+      this.#logWarn('[TIDE-POSTLOGOUT] could not set marker: ' + (e instanceof Error ? e.message : String(e)))
     }
     return this.#adapter.logout(options)
   }
@@ -1545,11 +1540,11 @@ export default class TideCloak {
       const ts = Number(raw)
       const fresh = Number.isFinite(ts) && (Date.now() - ts) < POST_LOGOUT_MARKER_TTL_MS
       if (!fresh) {
-        console.warn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
+        this.#logWarn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
       }
       return fresh
     } catch (e) {
-      console.warn('[TIDE-POSTLOGOUT] could not read marker:', e instanceof Error ? e.message : String(e))
+      this.#logWarn('[TIDE-POSTLOGOUT] could not read marker: ' + (e instanceof Error ? e.message : String(e)))
       return false
     }
   }

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -82,6 +82,14 @@ export default class TideCloak {
   /** @type {import('./tidecloak-dpop.js').DPoPSignatureProvider=} */
   #dpopProvider
 
+  /**
+   * The last non-matching `Authorization: Bearer …` value `secureFetch` warned
+   * about, so a consumer stuck in a stale-token state gets ONE warning per stale
+   * token rather than one per request. See `secureFetch`.
+   * @type {string|null}
+   */
+  #warnedStaleBearer = null
+
   /** @type {TideCloakConfig} config */
   #config
   didInitialize = false
@@ -1782,7 +1790,35 @@ export default class TideCloak {
       const isOurBearerToken = existingAuth === `Bearer ${this.token}`
 
       if (!isOurBearerToken) {
-        // Quick escape - didn't put this check in first if statement as it's more expensive than other checks
+        // Quick escape - didn't put this check in first if statement as it's more expensive than other checks.
+        //
+        // BEHAVIOUR IS UNCHANGED: a request carrying some OTHER Bearer token is a
+        // legitimate pass-through (a third-party API), so it goes out as a plain
+        // fetch with no DPoP proof.
+        //
+        // But make it OBSERVABLE. When the caller hands us a Bearer token that is
+        // almost-but-not-quite ours - i.e. a token this client issued them earlier
+        // and that has since gone stale because they cached it and missed a refresh
+        // - this silent downgrade is fatal and mute: a `dpop.bound.access.tokens`
+        // realm rejects a DPoP-bound token presented as a plain Bearer with a bare
+        // `401`, and nothing anywhere explains why. One warning per distinct stale
+        // token (not per request), so a wedged consumer gets a clear signal instead
+        // of a scrolling wall.
+        if (
+          typeof existingAuth === 'string' &&
+          existingAuth.startsWith('Bearer ') &&
+          existingAuth !== this.#warnedStaleBearer
+        ) {
+          this.#warnedStaleBearer = existingAuth
+          console.warn(
+            '[TIDECLOAK] secureFetch: the Authorization header carries a Bearer token that is NOT the ' +
+            'token this client currently holds. Sending it as a PLAIN fetch with no DPoP proof. If that ' +
+            'token came from this SDK it has gone STALE (the caller cached a copy and missed a refresh) ' +
+            'and a DPoP-bound realm will answer 401. Read the token from the SDK at call time ' +
+            '(IAMService.getToken()) instead of holding a copy, or omit the Authorization header entirely ' +
+            'and let secureFetch attach it.'
+          )
+        }
         return fetch(url, init)
       }
 

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -31,6 +31,15 @@ import { RequestEnclave, ApprovalEnclave, ApprovalEnclaveNew } from "heimdall-ti
 
 const CONTENT_TYPE_JSON = 'application/json'
 
+// Post-logout marker. After an explicit logout there is no session to silently
+// resume, so the immediately-following init() must skip the racy silent
+// check-sso (whose hidden iframe can net::ERR_ABORTED and wedge the app) and go
+// straight to interactive login. `logout()` stamps this durable localStorage
+// marker (survives the logout redirect round-trip); init() consumes it exactly
+// once and forces an interactive login when present + fresh.
+const POST_LOGOUT_MARKER_KEY = 'tide-post-logout'
+const POST_LOGOUT_MARKER_TTL_MS = 60000
+
 /**
  * @typedef {Object} Endpoints
  * @property {() => string} authorize
@@ -949,6 +958,15 @@ export default class TideCloak {
     }
 
     const onLoad = async () => {
+      // Post-logout deterministic path: if the previous logout stamped a fresh
+      // marker, skip silent check-sso entirely and go straight to interactive
+      // login. There is no session to silently resume after an explicit logout,
+      // and the silent path is exactly where the ERR_ABORTED wedge lives.
+      if (this.#consumePostLogoutMarker()) {
+        console.log('[TIDE-POSTLOGOUT] marker honored in init(); forcing interactive login, bypassing silent check-sso')
+        await doLogin(true)
+        return
+      }
       switch (initOptions.onLoad) {
         case 'check-sso':
           if (this.#loginIframe.enable) {
@@ -1091,23 +1109,38 @@ export default class TideCloak {
    * @returns {Promise<void>}
    */
   async #checkSsoSilently () {
+    console.log('[TIDE-SILENTSSO] start (timeout=' + this.silentCheckSsoTimeout + 'ms)')
     const iframe = document.createElement('iframe')
-    const src = await this.createLoginUrl({ prompt: 'none', redirectUri: this.silentCheckSsoRedirectUri })
-    iframe.setAttribute('src', src)
-    iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin')
-    iframe.setAttribute('title', 'keycloak-silent-check-sso')
-    iframe.style.display = 'none'
-    document.body.appendChild(iframe)
 
-    return await new Promise((resolve, reject) => {
+    return await new Promise((resolve) => {
       let settled = false
       /** @type {ReturnType<typeof setTimeout>=} */
       let timer
+      /** @type {ReturnType<typeof setTimeout>=} */
+      let loadGraceTimer
 
       const cleanup = () => {
         if (timer) clearTimeout(timer)
+        if (loadGraceTimer) clearTimeout(loadGraceTimer)
         window.removeEventListener('message', messageCallback)
+        iframe.removeEventListener('error', onIframeError)
+        iframe.removeEventListener('load', onIframeLoad)
         if (iframe.parentNode) document.body.removeChild(iframe)
+      }
+
+      // Every NON-authenticating terminal outcome funnels through here exactly
+      // once: onerror / onabort / load-without-message / timeout /
+      // createLoginUrl-failure. Resolving (never rejecting) as NOT-authenticated
+      // lets init() complete cleanly so the app falls through to interactive
+      // login. This is what makes the silent path structurally un-hangable: no
+      // matter which DOM event (or none) the aborted iframe produces, one of
+      // these fires. `via` is logged so QA can prove which path was taken.
+      const settleNotAuthenticated = (via) => {
+        if (settled) return
+        settled = true
+        console.warn('[TIDE-SILENTSSO] terminal=' + via + ' -> not-authenticated (authenticated=' + this.authenticated + ')')
+        cleanup()
+        resolve()
       }
 
       /**
@@ -1119,36 +1152,65 @@ export default class TideCloak {
         }
         if (settled) return
         settled = true
-
-        const oauth = this.#parseCallback(event.data)
         cleanup()
 
         try {
+          const oauth = this.#parseCallback(event.data)
           await this.#processCallback(oauth)
+          console.log('[TIDE-SILENTSSO] terminal=message -> processed (authenticated=' + this.authenticated + ')')
           resolve()
         } catch (error) {
-          reject(error)
+          // A failed silent callback must NOT reject: rejecting would surface as
+          // an init() error / AuthWall wall instead of a clean fall-through to
+          // interactive login. Resolve as not-authenticated.
+          console.warn('[TIDE-SILENTSSO] terminal=message-error -> not-authenticated:', error instanceof Error ? error.message : String(error))
+          resolve()
         }
       }
 
-      // Fail-fast guard: a silent check-sso must NEVER hang the init() promise.
-      // After an SDK-driven logout the doken/DPoP key is flushed; if the hidden
-      // check-sso iframe (or the Tide request enclave it may spin up) never
-      // posts back, init() would otherwise never resolve, isInitializing would
-      // stay true, and the SPA would wedge on "Signing you in..." forever
-      // (observed hang: 80s+). Resolve as NOT authenticated so init() completes
-      // cleanly and the app can fall through to an interactive login (which
-      // recovers). The happy path (valid session posts back in ~1-2s) settles
-      // well before this fires, so it is unchanged.
-      timer = setTimeout(() => {
-        if (settled) return
-        settled = true
-        this.#logWarn('[TIDECLOAK] Silent check-sso timed out after ' + this.silentCheckSsoTimeout + 'ms; treating as unauthenticated so the app can fall through to interactive login.')
-        cleanup()
-        resolve()
-      }, this.silentCheckSsoTimeout)
+      const onIframeError = () => settleNotAuthenticated('onerror')
 
+      const onIframeLoad = () => {
+        // The iframe finished navigating. On the happy path it landed on the
+        // real silent-check-sso.html and `messageCallback` settles first. If it
+        // loaded an error page, or a cross-origin KC page that never posts, or
+        // an aborted navigation that still fired `load`, no message arrives - so
+        // arm a short grace timer that settles NOT-authenticated well before the
+        // outer ceiling.
+        if (settled) return
+        const grace = Math.max(250, Math.min(2000, Math.floor(this.silentCheckSsoTimeout / 4)))
+        if (loadGraceTimer) clearTimeout(loadGraceTimer)
+        loadGraceTimer = setTimeout(() => settleNotAuthenticated('load-no-message'), grace)
+      }
+
+      // Wire ALL listeners before the navigation starts so no immediate event is
+      // missed. `error` covers the browsers that surface a failed iframe
+      // navigation as an error/abort event; `load` + the grace timer cover the
+      // ones that fire load on an error document; the outer `timer` covers
+      // net::ERR_ABORTED that produces NO DOM event at all.
       window.addEventListener('message', messageCallback)
+      iframe.addEventListener('error', onIframeError)
+      iframe.addEventListener('load', onIframeLoad)
+
+      // Hard ceiling. Created synchronously (NOT after an awaited createLoginUrl)
+      // so it is always armed regardless of what the iframe navigation does.
+      timer = setTimeout(() => settleNotAuthenticated('timeout'), this.silentCheckSsoTimeout)
+
+      // Build the URL and start the navigation. Failure here must still settle
+      // (not reject) so init() stays deterministic.
+      this.createLoginUrl({ prompt: 'none', redirectUri: this.silentCheckSsoRedirectUri })
+        .then((src) => {
+          if (settled) return
+          iframe.setAttribute('src', src)
+          iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin')
+          iframe.setAttribute('title', 'keycloak-silent-check-sso')
+          iframe.style.display = 'none'
+          document.body.appendChild(iframe)
+        })
+        .catch((error) => {
+          console.warn('[TIDE-SILENTSSO] createLoginUrl failed:', error instanceof Error ? error.message : String(error))
+          settleNotAuthenticated('createLoginUrl-error')
+        })
     })
   };
 
@@ -1453,7 +1515,43 @@ export default class TideCloak {
    */
   logout = async (options) => {
     await this.#dpopProvider?.flush()
+    // Stamp the post-logout marker so the next init() forces interactive login
+    // instead of running the racy silent check-sso. See POST_LOGOUT_MARKER_KEY.
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(POST_LOGOUT_MARKER_KEY, Date.now().toString())
+        console.log('[TIDE-POSTLOGOUT] marker set in logout(); next init() will force interactive login (skip silent check-sso)')
+      }
+    } catch (e) {
+      console.warn('[TIDE-POSTLOGOUT] could not set marker:', e instanceof Error ? e.message : String(e))
+    }
     return this.#adapter.logout(options)
+  }
+
+  /**
+   * Read + clear the post-logout marker. Returns true only when a marker was
+   * present AND fresh (set within POST_LOGOUT_MARKER_TTL_MS). Always clears the
+   * marker when present, so it fires at most once and a stale marker (a tab
+   * left open across a much later load) is discarded rather than forcing an
+   * unexpected interactive login.
+   * @returns {boolean}
+   */
+  #consumePostLogoutMarker () {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) return false
+      const raw = window.localStorage.getItem(POST_LOGOUT_MARKER_KEY)
+      if (!raw) return false
+      window.localStorage.removeItem(POST_LOGOUT_MARKER_KEY)
+      const ts = Number(raw)
+      const fresh = Number.isFinite(ts) && (Date.now() - ts) < POST_LOGOUT_MARKER_TTL_MS
+      if (!fresh) {
+        console.warn('[TIDE-POSTLOGOUT] marker present but stale (age > ' + POST_LOGOUT_MARKER_TTL_MS + 'ms); ignoring')
+      }
+      return fresh
+    } catch (e) {
+      console.warn('[TIDE-POSTLOGOUT] could not read marker:', e instanceof Error ? e.message : String(e))
+      return false
+    }
   }
 
   /**

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -92,6 +92,15 @@ export default class TideCloak {
   silentCheckSsoRedirectUri
   /** @type {boolean} */
   silentCheckSsoFallback = true
+  /**
+   * Max time (ms) to wait for the hidden silent-check-sso iframe to post back
+   * before treating the attempt as "not authenticated". Guards against the
+   * post-logout wedge where the check-sso (or the Tide enclave it spins up)
+   * never responds and init() would otherwise hang forever. Overridable via
+   * initOptions.silentCheckSsoTimeout.
+   * @type {number}
+   */
+  silentCheckSsoTimeout = 10000
   /** @type {TideCloakPkceMethod} */
   pkceMethod = 'S256'
   enableLogging = false
@@ -269,6 +278,10 @@ export default class TideCloak {
 
     if (typeof initOptions.silentCheckSsoFallback === 'boolean') {
       this.silentCheckSsoFallback = initOptions.silentCheckSsoFallback
+    }
+
+    if (typeof initOptions.silentCheckSsoTimeout === 'number' && initOptions.silentCheckSsoTimeout > 0) {
+      this.silentCheckSsoTimeout = initOptions.silentCheckSsoTimeout
     }
 
     if (typeof initOptions.pkceMethod !== 'undefined') {
@@ -1067,6 +1080,16 @@ export default class TideCloak {
     document.body.appendChild(iframe)
 
     return await new Promise((resolve, reject) => {
+      let settled = false
+      /** @type {ReturnType<typeof setTimeout>=} */
+      let timer
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        window.removeEventListener('message', messageCallback)
+        if (iframe.parentNode) document.body.removeChild(iframe)
+      }
+
       /**
        * @param {MessageEvent} event
        */
@@ -1074,8 +1097,11 @@ export default class TideCloak {
         if (event.origin !== window.location.origin || iframe.contentWindow !== event.source) {
           return
         }
+        if (settled) return
+        settled = true
 
         const oauth = this.#parseCallback(event.data)
+        cleanup()
 
         try {
           await this.#processCallback(oauth)
@@ -1083,10 +1109,24 @@ export default class TideCloak {
         } catch (error) {
           reject(error)
         }
-
-        document.body.removeChild(iframe)
-        window.removeEventListener('message', messageCallback)
       }
+
+      // Fail-fast guard: a silent check-sso must NEVER hang the init() promise.
+      // After an SDK-driven logout the doken/DPoP key is flushed; if the hidden
+      // check-sso iframe (or the Tide request enclave it may spin up) never
+      // posts back, init() would otherwise never resolve, isInitializing would
+      // stay true, and the SPA would wedge on "Signing you in..." forever
+      // (observed hang: 80s+). Resolve as NOT authenticated so init() completes
+      // cleanly and the app can fall through to an interactive login (which
+      // recovers). The happy path (valid session posts back in ~1-2s) settles
+      // well before this fires, so it is unchanged.
+      timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        this.#logWarn('[TIDECLOAK] Silent check-sso timed out after ' + this.silentCheckSsoTimeout + 'ms; treating as unauthenticated so the app can fall through to interactive login.')
+        cleanup()
+        resolve()
+      }, this.silentCheckSsoTimeout)
 
       window.addEventListener('message', messageCallback)
     })
@@ -1799,6 +1839,38 @@ export default class TideCloak {
   }
 
   /**
+   * Trigger a full interactive login redirect. Used as the recovery leg when a
+   * silent flow cannot proceed (e.g. the enclave asks for a doken refresh but
+   * the doken was flushed at logout). Navigates the whole page to Keycloak.
+   * @returns {Promise<void>}
+   */
+  async #reloginInteractively () {
+    await this.login({
+      idpHint: 'tide',
+      prompt: 'login',
+      redirectUri: window.location.href
+    })
+  }
+
+  /**
+   * Provide the current doken to the enclave, or fall through to interactive
+   * login when there is none (post-logout / flushed state). Throwing a bare
+   * error here would leave the enclave (and whatever awaits its doken-refresh
+   * completion) hanging; instead we redirect to a full interactive login, which
+   * recovers cleanly.
+   * @returns {Promise<string>}
+   */
+  async #provideDokenOrRelogin () {
+    await this.ensureTokenReady()
+    if (!this.doken) {
+      this.#logWarn('[TIDECLOAK] Enclave requested a doken refresh but no doken is present (post-logout). Falling through to interactive login.')
+      await this.#reloginInteractively()
+      throw new Error('[TIDECLOAK] No doken found - redirecting to interactive login')
+    }
+    return this.doken
+  }
+
+  /**
    * Initialize Tide RequestEnclave.
    */
   initRequestEnclave () {
@@ -1814,18 +1886,8 @@ export default class TideCloak {
         isRunningLocal: new URL(this.#getVoucherUrl()).hostname === "localhost"
       }).init({
         doken: this.doken,
-        dokenRefreshCallback: async () => {
-          await this.ensureTokenReady()
-          if (!this.doken) throw new Error('[TIDECLOAK] No doken found')
-          return this.doken
-        },
-        requireReloginCallback: async () => {
-          await this.login({
-            idpHint: 'tide',
-            prompt: 'login',
-            redirectUri: window.location.href
-          })
-        }
+        dokenRefreshCallback: async () => this.#provideDokenOrRelogin(),
+        requireReloginCallback: async () => this.#reloginInteractively()
       })
     }
   }
@@ -1847,18 +1909,8 @@ export default class TideCloak {
         backgroundUrl: this.#config['backgroundUrl'],
         logoUrl: this.#config['logoUrl'],
         doken: this.doken,
-        dokenRefreshCallback: async () => {
-          await this.ensureTokenReady()
-          if (!this.doken) throw new Error('[TIDECLOAK] No doken found')
-          return this.doken
-        },
-        requireReloginCallback: async () => {
-          await this.login({
-            idpHint: 'tide',
-            prompt: 'login',
-            redirectUri: window.location.href
-          })
-        }
+        dokenRefreshCallback: async () => this.#provideDokenOrRelogin(),
+        requireReloginCallback: async () => this.#reloginInteractively()
       })
     }
   }

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -60,6 +60,9 @@ const POST_LOGOUT_MARKER_TTL_MS = 60000
  * @property {string=} iframeOrigin
  */
 
+import { shouldAttachDpopProof } from './secureFetchPolicy.js'
+
+export { shouldAttachDpopProof } from './secureFetchPolicy.js'
 export { RequestEnclave, ApprovalEnclave, ApprovalEnclaveNew, PolicySignRequest } from "heimdall-tide";
 export { Tools, Models } from "@tideorg/js";
 export default class TideCloak {
@@ -1787,7 +1790,7 @@ export default class TideCloak {
     const dpopProvider = this.#dpopProvider
     if (dpopProvider && this.authenticated && this.token) {
       const existingAuth = new Headers(init.headers).get('Authorization')
-      const isOurBearerToken = existingAuth === `Bearer ${this.token}`
+      const isOurBearerToken = shouldAttachDpopProof(existingAuth, this.token)
 
       if (!isOurBearerToken) {
         // Quick escape - didn't put this check in first if statement as it's more expensive than other checks.

--- a/packages/tidecloak-js/lib/tidecloak.js
+++ b/packages/tidecloak-js/lib/tidecloak.js
@@ -1791,7 +1791,10 @@ export default class TideCloak {
    * Make sure enclave is up - attach this function to a user gesture.
    */
   #ensureRequestEnclaveOpen() {
-    if(!this.requestEnclave) return;
+    // Never (re)open the enclave without a doken. Post-logout the doken is
+    // flushed; reopening a dokenless hidden enclave wedges it with
+    // "Expecting doken in request".
+    if(!this.requestEnclave || !this.doken) return;
     this.requestEnclave.checkEnclaveOpen();
   }
 
@@ -2187,9 +2190,35 @@ export default class TideCloak {
     } else {
       delete this.doken
       delete this.dokenParsed
-      if (this.requestEnclave && typeof this.requestEnclave.updateDoken === 'function') {
-        this.requestEnclave.updateDoken(undefined)
+      // No doken present (e.g. post-logout / flushed state). Do NOT push a
+      // "doken refresh" into the enclave: refreshing with an undefined doken
+      // wedges the hidden enclave ("Expecting doken in request",
+      // TIDE-SWE-UNHANDLED) and blocks the silent re-auth that runs after
+      // logout. Instead tear the stale enclave(s) down so (a) no dokenless
+      // refresh is ever sent, (b) the persistent user-gesture listener can no
+      // longer reopen a dokenless hidden enclave (#ensureRequestEnclaveOpen
+      // no-ops once requestEnclave is cleared), and (c) the next authenticated
+      // flow re-creates a fresh enclave from a valid doken via
+      // initRequestEnclave(). The app is then free to fall through to an
+      // interactive login, which recovers cleanly.
+      this.#teardownEnclaves()
+    }
+  }
+
+  /**
+   * Close and discard any open Tide enclaves. Called when the doken is cleared
+   * (logout / flushed state) so stale enclaves can't be driven without a doken.
+   */
+  #teardownEnclaves () {
+    for (const key of ['requestEnclave', 'approvalEnclave']) {
+      const enclave = this[key]
+      if (!enclave) continue
+      try {
+        if (typeof enclave.close === 'function') enclave.close()
+      } catch (error) {
+        this.#logWarn('[TIDECLOAK] Failed to close ' + key + ': ' + (error instanceof Error ? error.message : error))
       }
+      this[key] = undefined
     }
   }
 

--- a/packages/tidecloak-js/package.json
+++ b/packages/tidecloak-js/package.json
@@ -24,6 +24,7 @@
     "./policy.css": "./dist/esm/src/policy.css"
   },
   "scripts": {
+    "test": "node --test test/*.test.js",
     "postinstall": "node ./scripts/postinstall.cjs",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/packages/tidecloak-js/package.json
+++ b/packages/tidecloak-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidecloak/js",
-  "version": "0.12.15",
+  "version": "0.14.0",
   "description": "Vanilla JavaScript/browser SDK for TideCloak with an IAMService singleton and low-level client.",
   "type": "module",
   "main": "dist/cjs/src/index.js",
@@ -57,11 +57,11 @@
     "authorization"
   ],
   "dependencies": {
-    "heimdall-tide": "^0.13.21",
-    "@tideorg/js": "^0.13.21"
+    "heimdall-tide": "^0.14.0",
+    "@tideorg/js": "^0.14.0"
   },
   "peerDependencies": {
-    "@tidecloak/policy": "*"
+    "@tidecloak/policy": "^0.14.0"
   },
   "peerDependenciesMeta": {
     "@tidecloak/policy": {

--- a/packages/tidecloak-js/package.json
+++ b/packages/tidecloak-js/package.json
@@ -24,7 +24,7 @@
     "./policy.css": "./dist/esm/src/policy.css"
   },
   "scripts": {
-    "test": "node --test test/*.test.js",
+    "test": "node --experimental-test-module-mocks --test test/*.test.js",
     "postinstall": "node ./scripts/postinstall.cjs",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/packages/tidecloak-js/src/AdminAPI.js
+++ b/packages/tidecloak-js/src/AdminAPI.js
@@ -29,6 +29,27 @@ class AdminAPI {
   }
 
   /**
+   * SAFETY INVARIANT: never send this SDK's own access token as a plain `Bearer`.
+   *
+   * When DPoP is enabled the issued token is sender-constrained (`typ: DPoP`,
+   * `cnf.jkt`), and RFC 9449 says a bound token presented as a plain `Bearer` is
+   * invalid - the server answers a bare `401` explaining nothing. So every admin
+   * call goes through `IAMService.secureFetch`, which:
+   *
+   *   - with a DPoP provider: upgrades `Authorization: Bearer <our token>` to
+   *     `Authorization: DPoP <our token>` + a `DPoP:` proof (and handles nonces);
+   *   - with no DPoP provider: falls through to a plain `fetch` - byte-for-byte
+   *     what this method did before.
+   *
+   * @private
+   */
+  async _authFetch(url, init) {
+    // Hybrid mode keeps tokens server-side and `secureFetch` refuses to run.
+    if (IAMService.isHybridMode?.()) return fetch(url, init);
+    return IAMService.secureFetch(url, init);
+  }
+
+  /**
    * Make an authenticated fetch request
    */
   async fetch(endpoint, options = {}) {
@@ -36,7 +57,7 @@ class AdminAPI {
     const baseURL = IAMService.getBaseUrl();
     const url = endpoint.startsWith('http') ? endpoint : `${baseURL}${endpoint}`;
 
-    const response = await fetch(url, {
+    const response = await this._authFetch(url, {
       ...options,
       headers: {
         'Content-Type': 'application/json',
@@ -62,7 +83,7 @@ class AdminAPI {
     const baseURL = IAMService.getBaseUrl();
     const url = endpoint.startsWith('http') ? endpoint : `${baseURL}${endpoint}`;
 
-    const response = await fetch(url, {
+    const response = await this._authFetch(url, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,
@@ -250,7 +271,7 @@ class AdminAPI {
 
     const url = `${baseURL}/admin/realms/${realm}/tideAdminResources/get-required-action-link?${params.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await this._authFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/tidecloak-js/src/IAMService.js
+++ b/packages/tidecloak-js/src/IAMService.js
@@ -1,4 +1,9 @@
-import { makePkce, fetchJson, resolveSilentCheckSsoRedirectUri } from "./utils/index.js";
+import {
+  makePkce,
+  fetchJson,
+  resolveSilentCheckSsoRedirectUri,
+  buildInitOptions,
+} from "./utils/index.js";
 import TideCloak, { RequestEnclave } from "../lib/tidecloak.js";
 
 /**
@@ -533,37 +538,15 @@ class IAMService {
       );
     }
 
-    const redirectUri = pick("redirectUri");
-    const silentCheckSsoFallback = pick("silentCheckSsoFallback");
-    const silentCheckSsoTimeout = pick("silentCheckSsoTimeout");
-    const scope = pick("scope");
-
     let authenticated = false;
     try {
-      authenticated = await this._tc.init({
-        setupRequestEnclave: config.setupRequestEnclave ?? true, // true by default because most clients that uses this will need it on
-        // NOTE: `onLoad` is deliberately NOT taken from the caller's config here.
-        // Callers (e.g. the admin console) pass `onLoad: "login-required"`, and
-        // honouring it would send #processInit down the `login-required` branch,
-        // which does a full top-level redirect on every load and never runs the
-        // silent check-sso path at all. That is a separate product decision, not
-        // part of fixing the redirect URI. Changing it belongs in its own change.
-        onLoad: "check-sso",
-        // `undefined` => TideCloak skips silent check-sso (see #processInit) and
-        // falls back to an interactive login rather than emitting a bad URI.
-        silentCheckSsoRedirectUri: silentSso.uri,
-        pkceMethod: pick("pkceMethod") ?? "S256",
-        // Forward the rest of the caller's init options instead of dropping them
-        // on the floor. `redirectUri` in particular must reach the TideCloak
-        // instance for sub-path-hosted apps, otherwise the adapter falls back to
-        // `location.href`.
-        ...(redirectUri !== undefined && { redirectUri }),
-        ...(silentCheckSsoFallback !== undefined && { silentCheckSsoFallback }),
-        ...(silentCheckSsoTimeout !== undefined && { silentCheckSsoTimeout }),
-        ...(scope !== undefined && { scope }),
-        ...(this._config?.useDPoP && { useDPoP: this._config.useDPoP }),
-        ...(this._config?.checkLoginIframe === false && { checkLoginIframe: false }),
-      });
+      authenticated = await this._tc.init(
+        buildInitOptions({
+          config: this._config ?? config,
+          setupRequestEnclave: config.setupRequestEnclave ?? true, // true by default because most clients that uses this will need it on
+          silentCheckSsoRedirectUri: silentSso.uri,
+        })
+      );
 
       // if successful, store token for middleware
       if (authenticated && this._tc.token) {

--- a/packages/tidecloak-js/src/IAMService.js
+++ b/packages/tidecloak-js/src/IAMService.js
@@ -133,6 +133,13 @@ class IAMService {
 
     // --- DPoP state ---
     this._dpopProvider = null;
+
+    // --- Front-channel init state ---
+    // Set while `_tc.init()` is in flight, cleared once it settles. Lets a
+    // concurrent/repeat `initIAM()` (React StrictMode double-mount, a provider
+    // effect that re-runs before the first init resolves) join the in-flight init
+    // instead of short-circuiting past it and reporting a not-yet-populated state.
+    this._frontchannelInitPromise = null;
   }
 
   /**
@@ -492,9 +499,54 @@ class IAMService {
 
     if (this._tc.didInitialize) {
       console.debug("[IAMService] IAM Already initialized once.");
-      return !!this._tc.tokenParsed;
+
+      // An init started by an EARLIER call may still be in flight (React
+      // StrictMode double-mounts; a provider effect that re-runs before the first
+      // init settles). Its trailing `_emit("ready", ...)` has not happened yet, so
+      // it will still reach the handler we registered at the top of this call -
+      // just join it and let the event do the work.
+      if (this._frontchannelInitPromise) {
+        return this._frontchannelInitPromise;
+      }
+
+      // Init has already SETTLED, and its `ready` event has been emitted and is
+      // gone. Anyone registering a handler after the fact - a React provider
+      // re-running its effect and re-subscribing after a `reload()` /
+      // `approveTideRequests()` - would hear NOTHING, forever. It would go on
+      // serving whatever auth state it last observed while this singleton kept
+      // refreshing its own token underneath.
+      //
+      // That desync is exactly how a `401` is manufactured: the consumer sends a
+      // stale `Authorization: Bearer <old token>`, `TideCloak.secureFetch` no
+      // longer recognises it as the token it holds, silently falls back to a plain
+      // non-DPoP `fetch`, and a `dpop.bound.access.tokens` realm rejects a
+      // DPoP-bound token presented as a plain Bearer.
+      //
+      // `ready` is a STATE notification, not a one-shot lifecycle signal, so
+      // re-emitting the current state is safe and idempotent - every listener
+      // simply re-syncs to the truth.
+      const alreadyAuthenticated = !!this._tc.tokenParsed;
+      this._emit("ready", alreadyAuthenticated);
+      return alreadyAuthenticated;
     }
 
+    this._frontchannelInitPromise = this._initFrontchannel(config);
+    try {
+      return await this._frontchannelInitPromise;
+    } finally {
+      this._frontchannelInitPromise = null;
+    }
+  }
+
+  /**
+   * Drive the one-and-only `TideCloak.init()` for front-channel mode and emit the
+   * resulting `ready` state. Split out of {@link initIAM} so the in-flight promise
+   * can be shared with concurrent callers.
+   * @private
+   * @param {Object} config
+   * @returns {Promise<boolean>}
+   */
+  async _initFrontchannel(config) {
     // Read an init option from the resolved config. `loadConfig` assigns
     // `this._config = config`, so these are normally the same object; we check
     // both so a caller that passes options only to `initIAM` is still honoured.
@@ -612,6 +664,30 @@ class IAMService {
       throw new Error("Config not loaded - call initIAM() first");
     }
     return this._config;
+  }
+
+  /**
+   * Whether initialization has already run to completion for the current mode.
+   *
+   * "Settled", not "started": while an init is still in flight this returns
+   * `false`, because the auth state it will produce does not exist yet and reading
+   * it would report a spurious logged-out state.
+   *
+   * Consumers that subscribe to events LATE (a React provider re-running its
+   * effect and re-subscribing, say) must use this to re-read the current auth
+   * state synchronously rather than waiting on a `ready` event that has already
+   * been emitted and is gone.
+   *
+   * @returns {boolean}
+   */
+  isInitialized() {
+    if (this.isHybridMode()) {
+      return this._hybridCallbackHandled && !this._hybridCallbackPromise;
+    }
+    if (this.isNativeMode()) {
+      return this._nativeCallbackHandled && !this._nativeCallbackPromise;
+    }
+    return !!this._tc?.didInitialize && !this._frontchannelInitPromise;
   }
 
   /** @returns {boolean} Whether there's a valid token (or session in hybrid/native mode) */

--- a/packages/tidecloak-js/src/IAMService.js
+++ b/packages/tidecloak-js/src/IAMService.js
@@ -1,4 +1,4 @@
-import { makePkce, fetchJson } from "./utils/index.js";
+import { makePkce, fetchJson, resolveSilentCheckSsoRedirectUri } from "./utils/index.js";
 import TideCloak, { RequestEnclave } from "../lib/tidecloak.js";
 
 /**
@@ -490,13 +490,77 @@ class IAMService {
       return !!this._tc.tokenParsed;
     }
 
+    // Read an init option from the resolved config. `loadConfig` assigns
+    // `this._config = config`, so these are normally the same object; we check
+    // both so a caller that passes options only to `initIAM` is still honoured.
+    const pick = (key) => this._config?.[key] ?? config?.[key];
+
+    // --- Silent-check-SSO redirect URI ---------------------------------------
+    // This used to be hardcoded to `${window.location.origin}/silent-check-sso.html`
+    // with NO caller override, which is only correct for an origin-root-hosted
+    // app. Any app served under a sub-path got a URI that is neither served nor
+    // registered on the OIDC client, so Keycloak answered `400 Invalid parameter:
+    // redirect_uri`, the silent iframe never posted back, and the app hung on its
+    // bootstrap spinner. Resolve it properly instead: an explicit caller value
+    // always wins, otherwise derive from the app's declared base. See
+    // ./utils/silentCheckSso.js.
+    const hasBaseElement =
+      typeof document !== "undefined" && !!document.querySelector("base[href]");
+    const silentSso = resolveSilentCheckSsoRedirectUri({
+      origin: window.location.origin,
+      configured: pick("silentCheckSsoRedirectUri"),
+      // `document.baseURI` is the browser's resolution of `<base href>`. Only pass
+      // it when such an element actually exists - otherwise it is just the current
+      // page URL, which for a deep SPA route would derive a bogus base.
+      baseHref: hasBaseElement ? document.baseURI : undefined,
+      redirectUri: pick("redirectUri"),
+    });
+
+    if (!silentSso.uri) {
+      // FAIL LOUD. Passing `undefined` makes TideCloak skip the silent check
+      // entirely and fall back to a redirect-based `prompt=none` login, which
+      // still authenticates the user. That is strictly better than emitting a
+      // URI we know will 400 and wedge the app on its spinner.
+      console.error(
+        `[IAMService] Cannot derive a silent-check-sso redirect URI: ${silentSso.reason}. ` +
+          "Skipping silent check-sso and falling back to a redirect-based login. " +
+          "Set `silentCheckSsoRedirectUri` in your TideCloak config to a URI that is " +
+          "both served by your app and registered on the OIDC client."
+      );
+    } else if (silentSso.source !== "config") {
+      console.debug(
+        `[IAMService] silentCheckSsoRedirectUri derived from ${silentSso.source}: ${silentSso.uri}`
+      );
+    }
+
+    const redirectUri = pick("redirectUri");
+    const silentCheckSsoFallback = pick("silentCheckSsoFallback");
+    const silentCheckSsoTimeout = pick("silentCheckSsoTimeout");
+    const scope = pick("scope");
+
     let authenticated = false;
     try {
       authenticated = await this._tc.init({
         setupRequestEnclave: config.setupRequestEnclave ?? true, // true by default because most clients that uses this will need it on
+        // NOTE: `onLoad` is deliberately NOT taken from the caller's config here.
+        // Callers (e.g. the admin console) pass `onLoad: "login-required"`, and
+        // honouring it would send #processInit down the `login-required` branch,
+        // which does a full top-level redirect on every load and never runs the
+        // silent check-sso path at all. That is a separate product decision, not
+        // part of fixing the redirect URI. Changing it belongs in its own change.
         onLoad: "check-sso",
-        silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
-        pkceMethod: "S256",
+        // `undefined` => TideCloak skips silent check-sso (see #processInit) and
+        // falls back to an interactive login rather than emitting a bad URI.
+        silentCheckSsoRedirectUri: silentSso.uri,
+        pkceMethod: pick("pkceMethod") ?? "S256",
+        // Forward the rest of the caller's init options instead of dropping them
+        // on the floor. `redirectUri` in particular must reach the TideCloak
+        // instance for sub-path-hosted apps, otherwise the adapter falls back to
+        // `location.href`.
+        ...(redirectUri !== undefined && { redirectUri }),
+        ...(silentCheckSsoFallback !== undefined && { silentCheckSsoFallback }),
+        ...(silentCheckSsoTimeout !== undefined && { silentCheckSsoTimeout }),
+        ...(scope !== undefined && { scope }),
         ...(this._config?.useDPoP && { useDPoP: this._config.useDPoP }),
         ...(this._config?.checkLoginIframe === false && { checkLoginIframe: false }),
       });

--- a/packages/tidecloak-js/src/IAMService.js
+++ b/packages/tidecloak-js/src/IAMService.js
@@ -203,23 +203,30 @@ class IAMService {
       console.warn("[loadConfig] empty config");
       return null;
     }
-    // Shallow-copy so we can normalise defaults without mutating the caller's object.
+    // Shallow-copy so we never mutate the caller's object.
     this._config = { ...config };
 
-    // DPoP is enabled and ENFORCED by default across all TideCloak SDKs. To weaken
-    // or disable it, set `useDPoP` explicitly:
-    //   - `useDPoP: false`              → disable DPoP entirely
-    //   - `useDPoP: { mode: 'auto' }`   → use DPoP only when the realm advertises it
-    //   - `useDPoP: { mode: 'strict' }` → require DPoP (the default); init fails if
-    //                                      the realm doesn't advertise DPoP support
-    const dpop = this._config.useDPoP;
-    if (dpop === false || dpop === null || dpop === "") {
-      delete this._config.useDPoP; // explicit opt-out
-    } else if (dpop === undefined || dpop === true) {
-      this._config.useDPoP = { mode: "strict" };
-    } else if (typeof dpop === "object" && dpop.mode === undefined) {
-      this._config.useDPoP = { ...dpop, mode: "strict" };
-    }
+    // ---------------------------------------------------------------------
+    // DPoP is OPT-IN. Do NOT default it on. Ever.
+    //
+    // `useDPoP` is passed through to `TideCloak.init()` VERBATIM and only when
+    // the caller actually set it (see ./utils/initOptions.js). If it is absent,
+    // no DPoP provider is constructed, no `dpop_jkt` is appended to the
+    // authorization request, and the realm issues a PLAIN access token.
+    //
+    // A previous revision defaulted this to `{ mode: "strict" }` whenever the
+    // caller omitted it ("DPoP on by default"). That silently broke every
+    // consumer that runs a deliberately non-DPoP flow: the authorization
+    // request grew a `dpop_jkt`, Keycloak issued a `typ: DPoP` /
+    // `cnf.jkt`-bound token, and the consumer's plain-Bearer fetch - correct
+    // for the flow it thought it was in - was rejected with a bare `401`
+    // (RFC 9449: a DPoP-bound token presented as a plain Bearer is invalid).
+    // The TideCloak admin console's bootstrap path is exactly this: it omits
+    // `useDPoP` on purpose and fetches with a plain Bearer.
+    //
+    // Enabling a sender-constraint the caller did not ask for changes the
+    // shape of the issued token. That is never a safe default to invent.
+    // ---------------------------------------------------------------------
 
     // Hybrid mode: do not construct TideCloak client (tokens are server-side)
     if (this.isHybridMode()) {

--- a/packages/tidecloak-js/src/tidecloak-js.d.ts
+++ b/packages/tidecloak-js/src/tidecloak-js.d.ts
@@ -327,6 +327,16 @@ export interface IAMServiceInstance {
   getConfig(): IAMConfig;
 
   /**
+   * Whether initialization has already run to COMPLETION for the current mode.
+   * `false` while an init is still in flight (its auth state does not exist yet).
+   *
+   * Use this when subscribing to events late - after a `ready` event may already
+   * have been emitted - to re-read the current auth state synchronously instead of
+   * waiting on an event that will never come again.
+   */
+  isInitialized(): boolean;
+
+  /**
    * Check if user is logged in.
    */
   isLoggedIn(): boolean;

--- a/packages/tidecloak-js/src/utils/index.js
+++ b/packages/tidecloak-js/src/utils/index.js
@@ -1,2 +1,3 @@
 export { makePkce, randomPkceVerifier, base64UrlEncode } from './pkce.js';
 export { fetchJson } from './fetch.js';
+export { resolveSilentCheckSsoRedirectUri, SILENT_CHECK_SSO_FILENAME } from './silentCheckSso.js';

--- a/packages/tidecloak-js/src/utils/index.js
+++ b/packages/tidecloak-js/src/utils/index.js
@@ -1,3 +1,4 @@
 export { makePkce, randomPkceVerifier, base64UrlEncode } from './pkce.js';
 export { fetchJson } from './fetch.js';
 export { resolveSilentCheckSsoRedirectUri, SILENT_CHECK_SSO_FILENAME } from './silentCheckSso.js';
+export { buildInitOptions } from './initOptions.js';

--- a/packages/tidecloak-js/src/utils/initOptions.js
+++ b/packages/tidecloak-js/src/utils/initOptions.js
@@ -1,0 +1,73 @@
+/**
+ * Builds the options object handed to `TideCloak.init()` from a caller's
+ * resolved TideCloak config.
+ *
+ * ## Why this is an ALLOWLIST, deliberately
+ *
+ * `IAMService.initIAM` has always built these options as an allowlist: it reads
+ * a handful of keys off the config and drops everything else on the floor. The
+ * config object is NOT a `KeycloakInitOptions` bag - it is an adapter/config
+ * snapshot (`tidecloak.json` + Tide fields + app-level OIDC hints), and callers
+ * legitimately put keys in it that are meaningful to `IAMService` (or to their
+ * own code) but that must NOT be handed to `init()`.
+ *
+ * PR #91 widened this allowlist to also forward `redirectUri`,
+ * `silentCheckSsoFallback`, `silentCheckSsoTimeout`, `scope` and a
+ * caller-supplied `pkceMethod`, on the reasoning that "each is inert unless the
+ * caller sets it". That reasoning is wrong in one important direction: consumers
+ * had been shipping configs with these keys set for as long as the keys were
+ * being SWALLOWED, so their behaviour was pinned to the SDK's defaults, not to
+ * the value in their config. Forwarding them is therefore a silent behaviour
+ * change for every existing consumer - the exact opposite of inert.
+ *
+ * `scope` is the sharpest edge: forwarding it rewrites the authorization
+ * request's scope, which changes the audience/roles on the issued access token
+ * and can strip a consumer's admin-API access.
+ *
+ * So: forward ONLY what the SDK genuinely needs, and keep the previously
+ * defaulted behaviour byte-for-byte. Any option that a consumer should be able
+ * to set must be added here CONSCIOUSLY, with its prior default preserved.
+ *
+ * ### Forwarded
+ * - `setupRequestEnclave` - passed through from the `initIAM` argument.
+ * - `onLoad` - always `"check-sso"`. NOT taken from config: callers (e.g. the
+ *   admin console) set `onLoad: "login-required"`, and honouring it would send
+ *   `#processInit` down the full-redirect branch and never run silent check-sso
+ *   at all. That is a separate product decision.
+ * - `silentCheckSsoRedirectUri` - the resolved URI (see ./silentCheckSso.js).
+ *   This is the ONE option PR #91 needed to make caller-supplied, and it stays.
+ *   `undefined` => TideCloak skips silent check-sso and falls back to an
+ *   interactive login rather than emitting a URI that would 400.
+ * - `pkceMethod` - always `"S256"`, as it was before PR #91.
+ * - `useDPoP` / `checkLoginIframe` - the two options `initIAM` has always
+ *   forwarded.
+ *
+ * ### Deliberately NOT forwarded (regression-tested in test/initOptions.test.js)
+ * `scope`, `redirectUri`, `silentCheckSsoFallback`, `silentCheckSsoTimeout`.
+ * Consumers depend on the SDK's defaults for these. `redirectUri` in particular
+ * is still READ from config by `IAMService.doLogin` / `doLogout` and is used as
+ * a derivation source for `silentCheckSsoRedirectUri`, so a sub-path-hosted app
+ * still gets a correct login redirect - it just does not have `kc.redirectUri`
+ * overridden at init time.
+ *
+ * @param {Object} args
+ * @param {Object|null|undefined} args.config Resolved TideCloak config.
+ * @param {boolean} args.setupRequestEnclave
+ * @param {string|undefined} args.silentCheckSsoRedirectUri Resolved URI, or
+ *   `undefined` when no correct URI could be derived.
+ * @returns {Object} Options for `TideCloak.init()`.
+ */
+export function buildInitOptions({
+  config,
+  setupRequestEnclave,
+  silentCheckSsoRedirectUri,
+}) {
+  return {
+    setupRequestEnclave,
+    onLoad: "check-sso",
+    silentCheckSsoRedirectUri,
+    pkceMethod: "S256",
+    ...(config?.useDPoP && { useDPoP: config.useDPoP }),
+    ...(config?.checkLoginIframe === false && { checkLoginIframe: false }),
+  };
+}

--- a/packages/tidecloak-js/src/utils/initOptions.js
+++ b/packages/tidecloak-js/src/utils/initOptions.js
@@ -40,7 +40,12 @@
  *   interactive login rather than emitting a URI that would 400.
  * - `pkceMethod` - always `"S256"`, as it was before PR #91.
  * - `useDPoP` / `checkLoginIframe` - the two options `initIAM` has always
- *   forwarded.
+ *   forwarded. `useDPoP` is forwarded ONLY when the caller actually set it, and
+ *   VERBATIM. DPoP is opt-in: nothing upstream may default it on, because
+ *   enabling it appends `dpop_jkt` to the authorization request and the realm
+ *   then issues a `cnf.jkt`-BOUND token, which a plain-Bearer consumer cannot
+ *   use (RFC 9449) - a bare `401` with no explanation. Pinned in
+ *   test/bootstrapDpop.test.js.
  *
  * ### Deliberately NOT forwarded (regression-tested in test/initOptions.test.js)
  * `scope`, `redirectUri`, `silentCheckSsoFallback`, `silentCheckSsoTimeout`.

--- a/packages/tidecloak-js/src/utils/silentCheckSso.js
+++ b/packages/tidecloak-js/src/utils/silentCheckSso.js
@@ -1,0 +1,143 @@
+/**
+ * Resolution of the silent-check-SSO redirect URI.
+ *
+ * ## Why this exists
+ *
+ * `IAMService.initIAM` used to hardcode:
+ *
+ * ```js
+ * silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`
+ * ```
+ *
+ * That is only correct for an app served from the ORIGIN ROOT. For any app
+ * hosted under a sub-path (e.g. a console served at
+ * `https://host/realms/<realm>/tide-console/`) the origin-root URI is:
+ *
+ *   - NOT served (there is no file at `/silent-check-sso.html`), and
+ *   - NOT a registered `redirectUri` on the OIDC client,
+ *
+ * so the authorization request fails with `400 Invalid parameter: redirect_uri`.
+ * The silent iframe then never posts back and the app hangs on its bootstrap
+ * spinner. A silently-wrong URI is the worst possible outcome, so this module
+ * either derives a CORRECT base-aware URI or reports that it cannot, letting
+ * the caller fail loud and fall back to a redirect-based login.
+ *
+ * ## Resolution order
+ *
+ * 1. **Caller-supplied `silentCheckSsoRedirectUri`** - always wins, verbatim.
+ * 2. **`<base href>`** - the standard way a sub-path-hosted SPA declares where
+ *    it lives. Resolved via the browser's own `document.baseURI`.
+ * 3. **The app's configured OIDC `redirectUri`** - the SDK already requires this
+ *    to be base-aware and registered, so it is a sound source of truth for the
+ *    app's base. The SDK's own convention is `<base>auth/redirect`, which is
+ *    stripped to recover `<base>` exactly; any other redirect path is resolved
+ *    relative to its own directory.
+ * 4. **Origin root** - only when the app declares NEITHER a base NOR a
+ *    redirectUri. Such an app is relying on the SDK's origin-root default
+ *    redirectUri (`${origin}/auth/redirect`) and is therefore root-hosted by
+ *    construction. This preserves the historical behaviour for every existing
+ *    root-hosted consumer.
+ *
+ * Anything that cannot be resolved (cross-origin or malformed redirectUri)
+ * returns `uri: undefined` plus a `reason`, so the caller can log an error and
+ * SKIP the silent check rather than emit a URI that will 400.
+ */
+
+/** Filename the SDK ships and that hosting providers are expected to serve. */
+export const SILENT_CHECK_SSO_FILENAME = 'silent-check-sso.html';
+
+/** The redirect path convention IAMService itself defaults to (`<base>auth/redirect`). */
+const AUTH_REDIRECT_SUFFIX = 'auth/redirect';
+
+/**
+ * @typedef {object} SilentCheckSsoResolution
+ * @property {string|undefined} uri    The resolved URI, or undefined if none could be derived.
+ * @property {'config'|'base-href'|'redirect-uri-convention'|'redirect-uri'|'origin-root'|'none'} source
+ * @property {string} [reason]         Why resolution failed (only when `uri` is undefined).
+ */
+
+/**
+ * Resolve the silent-check-SSO redirect URI.
+ *
+ * Pure: every environment input is passed in explicitly, so this is unit-testable
+ * with no DOM. See the module docblock for the resolution order.
+ *
+ * @param {object} params
+ * @param {string} params.origin        The app's origin (`window.location.origin`).
+ * @param {string} [params.configured]  Caller-supplied `silentCheckSsoRedirectUri`.
+ * @param {string} [params.baseHref]    `document.baseURI`, but ONLY when a `<base href>` element exists.
+ * @param {string} [params.redirectUri] Caller-supplied OIDC `redirectUri`.
+ * @returns {SilentCheckSsoResolution}
+ */
+export function resolveSilentCheckSsoRedirectUri ({ origin, configured, baseHref, redirectUri } = {}) {
+  // 1. An explicit value ALWAYS wins, on every init path. Dropping it is the bug
+  //    that took the sub-path-hosted console down.
+  if (isNonEmptyString(configured)) {
+    return { uri: configured.trim(), source: 'config' };
+  }
+
+  if (!isNonEmptyString(origin)) {
+    return { uri: undefined, source: 'none', reason: 'no origin available (non-browser context)' };
+  }
+
+  // 2. A declared <base href> is the app telling us exactly where it is hosted.
+  if (isNonEmptyString(baseHref)) {
+    try {
+      const base = new URL(baseHref, origin);
+      return { uri: new URL(SILENT_CHECK_SSO_FILENAME, base).href, source: 'base-href' };
+    } catch {
+      // Malformed <base href> - fall through to the redirectUri, which is more
+      // load-bearing anyway (login is already broken if it is wrong).
+    }
+  }
+
+  // 3. Derive the base from the app's own configured OIDC redirectUri.
+  if (isNonEmptyString(redirectUri)) {
+    let parsed;
+    try {
+      parsed = new URL(redirectUri, origin);
+    } catch {
+      return {
+        uri: undefined,
+        source: 'none',
+        reason: `configured redirectUri (${redirectUri}) is not a valid URL, so the app base cannot be derived`
+      };
+    }
+
+    if (parsed.origin !== origin) {
+      return {
+        uri: undefined,
+        source: 'none',
+        reason: `configured redirectUri (${redirectUri}) is on a different origin than the app (${origin}), so the app base cannot be derived`
+      };
+    }
+
+    // The SDK's own convention: `<base>auth/redirect`. Strip the suffix to
+    // recover `<base>` (keeping its trailing slash) rather than resolving
+    // relative to `<base>auth/`, which would be one directory too deep.
+    if (parsed.pathname.endsWith(`/${AUTH_REDIRECT_SUFFIX}`)) {
+      const basePath = parsed.pathname.slice(0, parsed.pathname.length - AUTH_REDIRECT_SUFFIX.length);
+      return {
+        uri: new URL(SILENT_CHECK_SSO_FILENAME, new URL(basePath, origin)).href,
+        source: 'redirect-uri-convention'
+      };
+    }
+
+    // Any other redirect path: resolve the filename against the redirect URI's
+    // own directory (`/app/callback` -> `/app/silent-check-sso.html`).
+    return { uri: new URL(SILENT_CHECK_SSO_FILENAME, parsed).href, source: 'redirect-uri' };
+  }
+
+  // 4. Neither a base nor a redirectUri was declared. The app is therefore
+  //    relying on the SDK's origin-root default redirectUri, i.e. it is
+  //    root-hosted, and origin-root is the right answer.
+  return { uri: `${origin}/${SILENT_CHECK_SSO_FILENAME}`, source: 'origin-root' };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isNonEmptyString (value) {
+  return typeof value === 'string' && value.trim() !== '';
+}

--- a/packages/tidecloak-js/test/bootstrapDpop.test.js
+++ b/packages/tidecloak-js/test/bootstrapDpop.test.js
@@ -1,0 +1,227 @@
+/**
+ * Regression tests for the BOOTSTRAP DPoP LEAK - the last of the blanket `401`s on
+ * the Keycloak admin API after 0.13.27 -> 0.13.34-staging.
+ *
+ * WIRE EVIDENCE (live browser, master realm, client `tide-console-bootstrap`):
+ *
+ *   0.13.27 (works):
+ *     authorize -> GET .../auth?client_id=…&prompt=none&code_challenge=…   [no dpop_jkt]
+ *     token     -> plain access token, not sender-constrained
+ *     admin     -> `Authorization: Bearer <tok>`                            -> 200
+ *
+ *   0.13.34-staging (401):
+ *     authorize -> GET .../auth?…&dpop_jkt=b9Yzg4rtocSEYfAUesRXGd6vJHI1NgncrTDvL8UKxKQ
+ *     token     -> { "typ": "DPoP", "cnf": { "jkt": "b9Yzg4…" } }
+ *     admin     -> `Authorization: Bearer <bound tok>` with NO `DPoP:` proof -> 401
+ *
+ * The chain: `IAMService.loadConfig` had started NORMALISING an absent `useDPoP`
+ * into `{ mode: "strict" }` ("DPoP enabled by default", commit 556d34d, shipped in
+ * 0.13.31). `buildInitOptions` forwards `useDPoP` whenever it is truthy, so the
+ * invented default reached `TideCloak.init()`, which built a DPoP provider, which
+ * appended `dpop_jkt` to the authorization request, which made Keycloak issue a
+ * `cnf.jkt`-BOUND token. The console's bootstrap path deliberately runs WITHOUT
+ * DPoP and fetches with a plain `Bearer` - and RFC 9449 says a bound token
+ * presented as a plain `Bearer` is invalid. Bare `401`, naming none of this.
+ *
+ * The guards in `lib/tidecloak.js` were never wrong and are unchanged:
+ *   - a provider is built only `if (this.useDPoP && this.dpopSigningAlgValuesSupported?.length)`
+ *   - `dpop_jkt` is appended only `if (this.#dpopProvider)`
+ *   - `this.useDPoP` is set only `if (initOptions.useDPoP)`
+ * `useDPoP` simply had no business being there.
+ *
+ * THE INVARIANT PINNED HERE: DPoP is OPT-IN. A config that does not ask for DPoP
+ * must produce an `init()` that does not mention DPoP - so no provider, so no
+ * `dpop_jkt`, so a plain (unbound) token that a plain-Bearer fetch can use.
+ *
+ * Run with: npm test (node:test + --experimental-test-module-mocks)
+ */
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildInitOptions } from '../src/utils/initOptions.js';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/** Minimal browser globals - IAMService touches `window` and `document`. */
+function installBrowserGlobals() {
+  globalThis.window = {
+    location: { origin: 'https://app.test', protocol: 'https:' },
+  };
+  globalThis.document = {
+    cookie: '',
+    baseURI: 'https://app.test/',
+    querySelector: () => null,
+  };
+}
+
+/** Stand-in for the real TideCloak client. Captures what `init()` was handed. */
+function makeFakeTideCloak() {
+  const seen = { initOptions: null, ctorConfig: null };
+
+  class FakeTideCloak {
+    didInitialize = false;
+    authenticated = false;
+    token = null;
+    tokenParsed = null;
+    idToken = null;
+    timeSkew = 0;
+
+    onReady;
+    onAuthSuccess;
+    onAuthError;
+    onAuthRefreshSuccess;
+    onAuthRefreshError;
+    onAuthLogout;
+    onTokenExpired;
+
+    constructor(cfg) {
+      seen.ctorConfig = cfg;
+    }
+
+    init = async (initOptions) => {
+      seen.initOptions = initOptions;
+      this.didInitialize = true;
+      this.authenticated = true;
+      this.token = 'TOKEN-1';
+      this.tokenParsed = { exp: Math.floor(Date.now() / 1000) + 300 };
+      this.onReady?.(this.authenticated);
+      return this.authenticated;
+    };
+  }
+
+  return { FakeTideCloak, seen };
+}
+
+// `mock.module` may only be registered ONCE per specifier, so register a stable
+// forwarding shim and let each test swap the class it delegates to.
+let CurrentFake = null;
+class TideCloakShim {
+  constructor(...args) {
+    if (!CurrentFake) throw new Error('test bug: no fake TideCloak installed');
+    return new CurrentFake(...args);
+  }
+}
+mock.module('../lib/tidecloak.js', {
+  defaultExport: TideCloakShim,
+  namedExports: { RequestEnclave: class {} },
+});
+
+/** A fresh IAMService singleton per test (the module exports one instance). */
+let importCounter = 0;
+async function freshIAMService(FakeTideCloak) {
+  CurrentFake = FakeTideCloak;
+  const mod = await import(`../src/IAMService.js?bootstrapDpop=${importCounter++}`);
+  return mod.default;
+}
+
+/**
+ * The tide-admin console's BOOTSTRAP config, verbatim in shape. The console does
+ *   `...(isBootstrap ? {} : { useDPoP: { mode: 'auto', alg: 'EdDSA' } })`
+ * i.e. bootstrap gets NO `useDPoP` key at all.
+ */
+const BOOTSTRAP_CONFIG = () => ({
+  'auth-server-url': 'https://app.test',
+  realm: 'master',
+  resource: 'tide-console-bootstrap',
+  redirectUri: 'https://app.test/realms/master/tide-console/auth/redirect',
+});
+
+/** Runs an init and hands back the options the client's `init()` actually saw. */
+async function initOptionsFor(config) {
+  installBrowserGlobals();
+  const { FakeTideCloak, seen } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+  await IAMService.initIAM(config);
+  return { opts: seen.initOptions, IAMService };
+}
+
+// ---------------------------------------------------------------------------
+// The regression: bootstrap must get a PLAIN, unbound token
+// ---------------------------------------------------------------------------
+
+test('no `useDPoP` in config -> `init()` receives no `useDPoP` -> no DPoP provider -> no dpop_jkt', async () => {
+  const { opts } = await initOptionsFor(BOOTSTRAP_CONFIG());
+
+  assert.ok(
+    !('useDPoP' in opts),
+    'DPoP is OPT-IN. A config that never mentions `useDPoP` must not grow one: ' +
+      '`TideCloak.init` sets `this.useDPoP` whenever `initOptions.useDPoP` is truthy, ' +
+      'builds a DPoP provider off it, and then appends `dpop_jkt` to the authorization ' +
+      'request - which makes Keycloak issue a `cnf.jkt`-bound token that the console\'s ' +
+      'plain-Bearer bootstrap fetch cannot use (RFC 9449) -> bare 401.'
+  );
+});
+
+test('loadConfig does not INVENT a `useDPoP` on the stored config', async () => {
+  // The leak was upstream of `buildInitOptions`: `loadConfig` normalised an absent
+  // `useDPoP` to `{ mode: "strict" }`, and the (correct, conditional) forwarding in
+  // `buildInitOptions` then dutifully passed the invention along.
+  const { IAMService } = await initOptionsFor(BOOTSTRAP_CONFIG());
+
+  assert.equal(
+    IAMService.getConfig().useDPoP,
+    undefined,
+    '`loadConfig` must store the caller\'s config as-is, not default DPoP on'
+  );
+});
+
+test('loadConfig does not mutate the caller\'s config object', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  const callerConfig = BOOTSTRAP_CONFIG();
+  await IAMService.initIAM(callerConfig);
+
+  assert.ok(!('useDPoP' in callerConfig), 'the caller\'s object must come back untouched');
+});
+
+// ---------------------------------------------------------------------------
+// The other direction: an EXPLICIT `useDPoP` still works, verbatim
+// ---------------------------------------------------------------------------
+
+test('an explicit `useDPoP` is forwarded VERBATIM - the caller\'s mode is not rewritten', async () => {
+  // The console's non-bootstrap path asks for `{ mode: 'auto', alg: 'EdDSA' }`.
+  // "auto" means "use DPoP only if the realm advertises it". The DPoP-by-default
+  // revision also silently upgraded a caller's mode to `strict`, which turns a
+  // realm that does not advertise DPoP from a graceful degrade into a hard init
+  // failure. The caller's stated mode is the caller's decision.
+  const useDPoP = { mode: 'auto', alg: 'EdDSA' };
+  const { opts } = await initOptionsFor({ ...BOOTSTRAP_CONFIG(), useDPoP });
+
+  assert.deepEqual(opts.useDPoP, useDPoP);
+});
+
+test('`useDPoP: false` is an explicit opt-out and never reaches init()', async () => {
+  const { opts } = await initOptionsFor({ ...BOOTSTRAP_CONFIG(), useDPoP: false });
+
+  assert.ok(!('useDPoP' in opts));
+});
+
+// ---------------------------------------------------------------------------
+// The forwarding seam itself (pure, no client)
+// ---------------------------------------------------------------------------
+
+test('buildInitOptions omits `useDPoP` entirely when the config has none', () => {
+  const opts = buildInitOptions({
+    config: BOOTSTRAP_CONFIG(),
+    setupRequestEnclave: true,
+    silentCheckSsoRedirectUri: 'https://app.test/silent-check-sso.html',
+  });
+
+  assert.ok(!('useDPoP' in opts));
+});
+
+test('buildInitOptions omits `useDPoP` when the config is null/undefined', () => {
+  for (const config of [null, undefined]) {
+    const opts = buildInitOptions({
+      config,
+      setupRequestEnclave: true,
+      silentCheckSsoRedirectUri: 'https://app.test/silent-check-sso.html',
+    });
+    assert.ok(!('useDPoP' in opts), `config=${config}`);
+  }
+});

--- a/packages/tidecloak-js/test/dpopAdminFetch.test.js
+++ b/packages/tidecloak-js/test/dpopAdminFetch.test.js
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for the ADMIN-API `401` that survived BOTH the PR #91
+ * silent-check-sso redirect fix AND the `2bf1202` React/SDK token-desync fix.
+ *
+ * The residual mechanism was not a stale token and not a missing DPoP key. It was
+ * an authenticated-but-TOKENLESS window:
+ *
+ *   1. `IAMService._emit("ready")` invokes its listeners WITHOUT awaiting them -
+ *      it is a synchronous emitter, it cannot await them.
+ *   2. `@tidecloak/react`'s `updateAuthState` listener called `setAuthenticated(true)`
+ *      synchronously and only THEN `await IAMService.getToken()` to fill `token`.
+ *   3. So `initIAM()` resolved, `TideCloakContextProvider` cleared `isInitializing`,
+ *      and React committed a render of `{ authenticated: true, token: null }`.
+ *   4. The app un-gated on that render and consumers fired admin calls immediately
+ *      (react-query fires on subscribe). They read `token` from context, got `null`,
+ *      and sent `GET /admin/realms` with NO `Authorization` header at all.
+ *   5. `401`. Not "a DPoP-bound token presented as plain Bearer" - NO CREDENTIALS.
+ *
+ * The primary fix is in TideCloakContextProvider.tsx: the token is now published in
+ * the SAME committed render that first reports `authenticated`, so the window in
+ * which a consumer can read `authenticated: true` with a null token no longer
+ * exists.
+ *
+ * Pinned HERE is the SDK's side of that seam - `shouldAttachDpopProof`, the
+ * predicate `secureFetch` uses to decide whether to attach our token + a DPoP
+ * proof. A caller that supplies NO Authorization header must get an AUTHENTICATED,
+ * DPoP-bound request, not a silent credential-less plain fetch. That closes the
+ * whole class of bug: even if some consumer manages to call before its token is to
+ * hand, the SDK now signs the request with the token it holds.
+ *
+ * Run with: npm test (node:test)
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// The predicate `TideCloak.secureFetch` (lib/tidecloak.js) uses to decide whether
+// to sign a request as its own. It lives in its own module because lib/tidecloak.js
+// pulls in `heimdall-tide`, which will not load under plain node ESM.
+import { shouldAttachDpopProof } from '../lib/secureFetchPolicy.js';
+
+const OUR_TOKEN = 'ACCESS_TOKEN_A';
+
+// ---------------------------------------------------------------------------
+// The bug: no Authorization header -> credential-less plain fetch -> bare 401
+// ---------------------------------------------------------------------------
+
+test('NO Authorization header -> attach our token + a DPoP proof (was: plain unauthenticated fetch)', () => {
+  // This is EXACTLY the failing console call. `usePlainBearerFetch` /
+  // `useSecureFetch` do `const token = tc.token; if (token) headers.set(...)`.
+  // With `tc.token === null` no header is set at all, and pre-fix this returned
+  // false -> `fetch(url, init)` with no credentials -> Keycloak answers 401.
+  assert.equal(
+    shouldAttachDpopProof(null, OUR_TOKEN),
+    true,
+    'a request with no Authorization header must be signed with the SDK token',
+  );
+});
+
+test('an ABSENT (undefined) Authorization header is treated the same as a null one', () => {
+  // `new Headers().get()` returns null, but a caller passing a bare object may
+  // hand us `undefined`. Both mean "I set no Authorization".
+  assert.equal(shouldAttachDpopProof(undefined, OUR_TOKEN), true);
+});
+
+// ---------------------------------------------------------------------------
+// No regressions: the two pre-existing behaviours must be preserved exactly
+// ---------------------------------------------------------------------------
+
+test('OUR bearer token is still upgraded to DPoP (unchanged)', () => {
+  assert.equal(shouldAttachDpopProof(`Bearer ${OUR_TOKEN}`, OUR_TOKEN), true);
+});
+
+test("SOMEONE ELSE'S bearer token is still passed through as a plain fetch (unchanged)", () => {
+  // A third-party API call is a legitimate pass-through: it must go out verbatim
+  // and must never be handed one of our DPoP proofs.
+  assert.equal(
+    shouldAttachDpopProof('Bearer SOMEONE_ELSES_TOKEN', OUR_TOKEN),
+    false,
+    'a third-party bearer must not be rewritten, and must not receive our proof',
+  );
+});
+
+test('a STALE copy of one of our own tokens is still NOT signed (unchanged)', () => {
+  // This is the `2bf1202` desync case: a consumer cached our token, missed a
+  // refresh, and handed it back. It is no longer our token, so it is not ours to
+  // sign - it stays a plain fetch (and `secureFetch` warns once). Preserving this
+  // keeps the 2bf1202 warning path reachable.
+  assert.equal(shouldAttachDpopProof('Bearer STALE_TOKEN_FROM_LAST_REFRESH', OUR_TOKEN), false);
+});
+
+test('a non-Bearer scheme (Basic, DPoP, …) is left alone', () => {
+  assert.equal(shouldAttachDpopProof('Basic dXNlcjpwYXNz', OUR_TOKEN), false);
+  assert.equal(shouldAttachDpopProof(`DPoP ${OUR_TOKEN}`, OUR_TOKEN), false);
+});
+
+test('the match is exact - a token that merely PREFIXES ours is not ours', () => {
+  assert.equal(shouldAttachDpopProof(`Bearer ${OUR_TOKEN}_EXTRA`, OUR_TOKEN), false);
+  assert.equal(shouldAttachDpopProof('Bearer ACCESS_TOKEN', OUR_TOKEN), false);
+});

--- a/packages/tidecloak-js/test/initOptions.test.js
+++ b/packages/tidecloak-js/test/initOptions.test.js
@@ -1,0 +1,168 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildInitOptions } from "../src/utils/initOptions.js";
+
+/**
+ * Regression tests for the `TideCloak.init()` option ALLOWLIST.
+ *
+ * Background: PR #91 (0.13.34-staging) fixed the silent-check-sso redirect URI
+ * but ALSO started forwarding `scope`, `redirectUri`, `silentCheckSsoFallback`,
+ * `silentCheckSsoTimeout` and a caller-supplied `pkceMethod` from config into
+ * `init()`. Those keys had been silently swallowed for the SDK's whole life, so
+ * consumers' configs carried values whose behaviour was actually pinned to the
+ * SDK defaults. Forwarding them is a silent behaviour change for every existing
+ * consumer.
+ *
+ * `scope` is the sharpest edge: it rewrites the authorization request's scope,
+ * which changes the audience/roles on the issued access token and can strip a
+ * consumer's Keycloak admin-API access (observable as `401` on `/admin/realms`).
+ *
+ * These tests pin the allowlist so it cannot be widened by accident again.
+ */
+
+/** A config shaped like a real consumer's (the tide-admin console). */
+function consoleLikeConfig(extra = {}) {
+  return {
+    url: "http://localhost:8080",
+    realm: "master",
+    clientId: "tide-admin-console",
+    onLoad: "login-required",
+    pkceMethod: "S256",
+    responseMode: "query",
+    silentCheckSsoRedirectUri:
+      "http://localhost:8080/realms/demo/tide-console/silent-check-sso.html",
+    silentCheckSsoFallback: true,
+    checkLoginIframe: true,
+    redirectUri: "http://localhost:8080/realms/demo/tide-console/auth/redirect",
+    ...extra,
+  };
+}
+
+const OPTS = {
+  setupRequestEnclave: true,
+  silentCheckSsoRedirectUri:
+    "http://localhost:8080/realms/demo/tide-console/silent-check-sso.html",
+};
+
+test("never forwards `scope` - even when the config sets one", () => {
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({ scope: "openid profile" }),
+    ...OPTS,
+  });
+
+  assert.ok(
+    !("scope" in opts),
+    "`scope` must NOT reach init(): it rewrites the authorization request scope, " +
+      "changing the issued token's audience/roles (401 on the Keycloak admin API)."
+  );
+});
+
+test("never forwards redirectUri / silentCheckSsoFallback / silentCheckSsoTimeout", () => {
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({ silentCheckSsoTimeout: 3000 }),
+    ...OPTS,
+  });
+
+  for (const key of [
+    "redirectUri",
+    "silentCheckSsoFallback",
+    "silentCheckSsoTimeout",
+  ]) {
+    assert.ok(
+      !(key in opts),
+      `\`${key}\` must NOT reach init() - consumers depend on the SDK default ` +
+        "that applied while the option was being swallowed."
+    );
+  }
+});
+
+test("pkceMethod is always S256, never taken from config", () => {
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({ pkceMethod: false }),
+    ...OPTS,
+  });
+
+  assert.equal(opts.pkceMethod, "S256");
+});
+
+test("onLoad is always check-sso, never taken from config", () => {
+  const opts = buildInitOptions({
+    // The console really does set `login-required`; honouring it would skip the
+    // silent check-sso path entirely.
+    config: consoleLikeConfig({ onLoad: "login-required" }),
+    ...OPTS,
+  });
+
+  assert.equal(opts.onLoad, "check-sso");
+});
+
+test("the resolved silentCheckSsoRedirectUri IS forwarded (the PR #91 fix stays)", () => {
+  const uri =
+    "http://localhost:8080/realms/demo/tide-console/silent-check-sso.html";
+  const opts = buildInitOptions({
+    config: consoleLikeConfig(),
+    setupRequestEnclave: true,
+    silentCheckSsoRedirectUri: uri,
+  });
+
+  assert.equal(opts.silentCheckSsoRedirectUri, uri);
+});
+
+test("an undefined silentCheckSsoRedirectUri is passed through as undefined", () => {
+  // => TideCloak skips silent check-sso and falls back to an interactive login,
+  // rather than emitting an origin-root URI that would 400.
+  const opts = buildInitOptions({
+    config: consoleLikeConfig(),
+    setupRequestEnclave: true,
+    silentCheckSsoRedirectUri: undefined,
+  });
+
+  assert.ok("silentCheckSsoRedirectUri" in opts);
+  assert.equal(opts.silentCheckSsoRedirectUri, undefined);
+});
+
+test("useDPoP and checkLoginIframe are still forwarded (long-standing behaviour)", () => {
+  const useDPoP = { mode: "auto", alg: "EdDSA" };
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({ useDPoP, checkLoginIframe: false }),
+    ...OPTS,
+  });
+
+  assert.deepEqual(opts.useDPoP, useDPoP);
+  assert.equal(opts.checkLoginIframe, false);
+});
+
+test("checkLoginIframe is omitted unless it is exactly false", () => {
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({ checkLoginIframe: true }),
+    ...OPTS,
+  });
+
+  assert.ok(!("checkLoginIframe" in opts));
+});
+
+test("the full option set is exactly the allowlist - nothing leaks through", () => {
+  // A config carrying every key we deliberately drop, plus junk.
+  const opts = buildInitOptions({
+    config: consoleLikeConfig({
+      scope: "openid profile email",
+      silentCheckSsoTimeout: 3000,
+      useDPoP: { mode: "auto", alg: "EdDSA" },
+      somethingElseEntirely: "junk",
+      vendorId: "abc123",
+    }),
+    ...OPTS,
+  });
+
+  assert.deepEqual(
+    Object.keys(opts).sort(),
+    [
+      "onLoad",
+      "pkceMethod",
+      "setupRequestEnclave",
+      "silentCheckSsoRedirectUri",
+      "useDPoP",
+    ].sort()
+  );
+});

--- a/packages/tidecloak-js/test/readyResync.test.js
+++ b/packages/tidecloak-js/test/readyResync.test.js
@@ -1,0 +1,300 @@
+/**
+ * Regression tests for the React <-> SDK TOKEN DESYNC that surfaced as a blanket
+ * `401` on every Keycloak admin API call after 0.13.27 -> 0.13.34-staging.
+ *
+ * The mechanism, end to end:
+ *
+ *   1. `initIAM()` used to short-circuit on `this._tc.didInitialize` and return
+ *      WITHOUT emitting `ready` - even though it had just registered the caller's
+ *      `onReady` handler one line earlier.
+ *   2. `TideCloakContextProvider` (@tidecloak/react) tears its handlers down on
+ *      effect cleanup - including the `ready` handler - and re-subscribes when the
+ *      effect re-runs (a `reloadKey` bump from `reload()` / `approveTideRequests()`,
+ *      a `resolvedConfig` identity change, a StrictMode double-mount).
+ *   3. So after any re-run, the provider's freshly-registered handlers heard
+ *      NOTHING, forever. React kept serving the `token` it last cached while the
+ *      SDK went on refreshing its own underneath.
+ *   4. Consumers read that stale `token` from context into an
+ *      `Authorization: Bearer …` header. `TideCloak.secureFetch` compares it
+ *      against the token it actually holds (lib/tidecloak.js), no longer recognises
+ *      it as its own, and silently falls back to a plain non-DPoP `fetch`.
+ *   5. A `dpop.bound.access.tokens=true` realm rejects a DPoP-bound token presented
+ *      as a plain Bearer -> `401`, with nothing anywhere saying why.
+ *
+ * An event is a moment, not a value. These tests pin the two guarantees that make
+ * a late subscriber correct anyway:
+ *
+ *   - `initIAM()` re-emits `ready` with the CURRENT state when it short-circuits
+ *     on an already-settled init.
+ *   - `isInitialized()` tells a late subscriber it may read that state directly,
+ *     and is `false` while an init is still in flight (the state doesn't exist yet).
+ *
+ * Run with: npm test (node:test + --experimental-test-module-mocks)
+ */
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/** Minimal browser globals - IAMService touches `window` and `document`. */
+function installBrowserGlobals() {
+  globalThis.window = {
+    location: { origin: 'https://app.test', protocol: 'https:' },
+  };
+  globalThis.document = {
+    cookie: '',
+    baseURI: 'https://app.test/',
+    // No <base href> element -> silent-check-sso derives from redirectUri.
+    querySelector: () => null,
+  };
+}
+
+/**
+ * Stand-in for the real TideCloak client. Mirrors the two behaviours that matter:
+ * `didInitialize` flips SYNCHRONOUSLY at the top of `init()` (so a concurrent
+ * caller sees it before the init settles), and `onReady` fires exactly once, when
+ * the init settles.
+ */
+function makeFakeTideCloak() {
+  /** Resolves the in-flight `init()`. Lets a test hold init open. */
+  let releaseInit;
+  const initGate = new Promise((resolve) => { releaseInit = resolve; });
+  const stats = { initCount: 0 };
+
+  class FakeTideCloak {
+    didInitialize = false;
+    authenticated = false;
+    token = null;
+    tokenParsed = null;
+    idToken = null;
+    timeSkew = 0;
+
+    onReady;
+    onAuthSuccess;
+    onAuthError;
+    onAuthRefreshSuccess;
+    onAuthRefreshError;
+    onAuthLogout;
+    onTokenExpired;
+
+    init = async () => {
+      // The real client throws if init'd twice; nothing may drive it there.
+      if (this.didInitialize) {
+        throw new Error("A 'TideCloak' instance can only be initialized once.");
+      }
+      this.didInitialize = true;
+      stats.initCount += 1;
+
+      await initGate;
+
+      this.authenticated = true;
+      this.token = 'TOKEN-1';
+      this.tokenParsed = { exp: Math.floor(Date.now() / 1000) + 300 };
+      this.onReady?.(this.authenticated);
+      return this.authenticated;
+    };
+
+    /** Simulate a background refresh: new token + the event the SDK really fires. */
+    refresh(newToken) {
+      this.token = newToken;
+      this.tokenParsed = { exp: Math.floor(Date.now() / 1000) + 300 };
+      this.onAuthRefreshSuccess?.();
+    }
+  }
+
+  return { FakeTideCloak, stats, releaseInit: () => releaseInit() };
+}
+
+// `mock.module` may only be registered ONCE per specifier, so register a stable
+// forwarding shim and let each test swap the class it delegates to. A constructor
+// that returns an object yields that object, so `new TideCloakShim(cfg)` really is
+// a `CurrentFake`.
+let CurrentFake = null;
+class TideCloakShim {
+  constructor(...args) {
+    if (!CurrentFake) throw new Error('test bug: no fake TideCloak installed');
+    return new CurrentFake(...args);
+  }
+}
+mock.module('../lib/tidecloak.js', {
+  defaultExport: TideCloakShim,
+  namedExports: { RequestEnclave: class {} },
+});
+
+/** A fresh IAMService singleton per test (the module exports one instance). */
+let importCounter = 0;
+async function freshIAMService(FakeTideCloak) {
+  CurrentFake = FakeTideCloak;
+  const mod = await import(`../src/IAMService.js?fresh=${importCounter++}`);
+  return mod.default;
+}
+
+const CONFIG = () => ({
+  'auth-server-url': 'https://app.test',
+  realm: 'master',
+  resource: 'tide-admin-console',
+  redirectUri: 'https://app.test/realms/master/tide-console/auth/redirect',
+});
+
+/**
+ * The contract is "a subscriber is ALWAYS told the current state", not "told
+ * exactly once". A fresh init has always emitted `ready` twice - once from
+ * `TideCloak.onReady`, once from IAMService's own trailing emit - and `ready` is a
+ * state notification, so extra emissions are harmless. What is fatal is ZERO.
+ */
+function assertToldReady(seen, expected, message) {
+  assert.ok(seen.length > 0, `${message} (heard nothing at all)`);
+  assert.deepEqual(
+    [...new Set(seen)],
+    [expected],
+    `${message} (every emission must carry the current state)`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The regression
+// ---------------------------------------------------------------------------
+
+test('a handler registered AFTER init settled still receives the current auth state', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak, stats, releaseInit } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  // --- First mount: the provider subscribes and drives init. ---
+  const firstMount = [];
+  const firstHandler = (_event, authenticated) => firstMount.push(authenticated);
+  releaseInit();
+  await IAMService.initIAM(CONFIG(), firstHandler);
+
+  assertToldReady(firstMount, true, 'the first subscriber must see ready(true)');
+
+  // --- Effect cleanup: the provider removes its `ready` handler. ---
+  IAMService.off('ready', firstHandler);
+
+  // --- Effect re-run (reload() / approveTideRequests() / StrictMode): the
+  //     provider re-subscribes with a BRAND NEW closure and calls initIAM again.
+  const secondMount = [];
+  const secondHandler = (_event, authenticated) => secondMount.push(authenticated);
+  const result = await IAMService.initIAM(CONFIG(), secondHandler);
+
+  // THE BUG: this used to be `[]`. The re-registered handler heard nothing, so the
+  // provider's `token` stayed frozen at whatever it last cached -> stale Bearer ->
+  // silent non-DPoP downgrade -> 401.
+  assertToldReady(
+    secondMount,
+    true,
+    're-initializing must re-emit `ready` so a re-subscribed handler re-syncs'
+  );
+  assert.equal(result, true, 'initIAM must still report the current auth state');
+
+  // And it must NOT have driven a second TideCloak.init() (the client throws).
+  assert.equal(stats.initCount, 1, 'the underlying client is init`d exactly once');
+});
+
+test('the re-emitted state is read live from the client, not a cached boolean', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak, stats, releaseInit } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  releaseInit();
+  await IAMService.initIAM(CONFIG());
+
+  // The session dies underneath us (logout elsewhere, refresh token revoked).
+  IAMService._tc.token = null;
+  IAMService._tc.tokenParsed = null;
+
+  const seen = [];
+  const authenticated = await IAMService.initIAM(CONFIG(), (_e, a) => seen.push(a));
+
+  assertToldReady(seen, false, 'a late subscriber must be told the session is gone');
+  assert.equal(authenticated, false);
+});
+
+test('a token refreshed after a re-subscribe is visible to the re-subscribed handler', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak, stats, releaseInit } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  releaseInit();
+  const readyHandler = () => {};
+  await IAMService.initIAM(CONFIG(), readyHandler);
+
+  // Effect re-run: drop every handler, re-subscribe fresh ones.
+  IAMService.off('ready', readyHandler);
+  const tokensSeen = [];
+  const resync = async () => { tokensSeen.push(await IAMService.getToken()); };
+  IAMService.on('authRefreshSuccess', resync);
+  await IAMService.initIAM(CONFIG(), resync);
+
+  // The re-subscribed handler must have re-synced immediately off `ready`...
+  assert.deepEqual(tokensSeen, ['TOKEN-1']);
+
+  // ...and must keep tracking the SDK across a background refresh. This is the
+  // second desync path: if the refresh event never reached React, the cached token
+  // would go stale on the first refresh even with no re-init at all.
+  IAMService._tc.refresh('TOKEN-2');
+  await new Promise((r) => setImmediate(r));
+
+  assert.deepEqual(
+    tokensSeen,
+    ['TOKEN-1', 'TOKEN-2'],
+    'authRefreshSuccess must reach the re-subscribed handler with the NEW token'
+  );
+  assert.equal(await IAMService.getToken(), IAMService._tc.token, 'never desynced from the SDK');
+});
+
+// ---------------------------------------------------------------------------
+// isInitialized() - the synchronous escape hatch for a late subscriber
+// ---------------------------------------------------------------------------
+
+test('isInitialized() is false before init, false DURING init, true once settled', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak, stats, releaseInit } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  assert.equal(IAMService.isInitialized(), false, 'nothing has been initialized yet');
+
+  const inFlight = IAMService.initIAM(CONFIG());
+  await new Promise((r) => setImmediate(r));
+
+  // `didInitialize` is already true here - but the auth state it will produce does
+  // not exist yet. Reporting "initialized" now would make a late subscriber read a
+  // spurious logged-OUT state and blow its token away.
+  assert.equal(
+    IAMService.isInitialized(),
+    false,
+    'an in-flight init is NOT settled - its auth state does not exist yet'
+  );
+
+  releaseInit();
+  await inFlight;
+
+  assert.equal(IAMService.isInitialized(), true);
+});
+
+test('an initIAM that lands mid-init joins it rather than short-circuiting past it', async () => {
+  installBrowserGlobals();
+  const { FakeTideCloak, stats, releaseInit } = makeFakeTideCloak();
+  const IAMService = await freshIAMService(FakeTideCloak);
+
+  // Mount 1 kicks off init...
+  const first = IAMService.initIAM(CONFIG());
+  await new Promise((r) => setImmediate(r));
+
+  // ...and StrictMode immediately re-runs the effect: `didInitialize` is ALREADY
+  // true, so the old code short-circuited and returned `!!tokenParsed` === false -
+  // handing React a logged-out state while a perfectly good login was in flight.
+  const seen = [];
+  const second = IAMService.initIAM(CONFIG(), (_e, a) => seen.push(a));
+
+  releaseInit();
+  const [a1, a2] = await Promise.all([first, second]);
+
+  assert.equal(a1, true);
+  assert.equal(a2, true, 'the second caller must await the in-flight init, not guess');
+  assertToldReady(seen, true, 'and its handler must be told the real, settled state');
+  assert.equal(stats.initCount, 1);
+});

--- a/packages/tidecloak-js/test/silentCheckSso.test.js
+++ b/packages/tidecloak-js/test/silentCheckSso.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for the silent-check-SSO redirect URI resolver.
+ *
+ * Run with: npm test  (uses node:test - no external dependencies)
+ *
+ * The regression these lock down: a sub-path-hosted app (e.g. a console served
+ * at `https://host/realms/<realm>/tide-console/`) used to get the hardcoded
+ * origin-root URI `https://host/silent-check-sso.html`, which is neither served
+ * nor a registered redirectUri -> `400 Invalid parameter: redirect_uri` -> the
+ * silent iframe never posts back -> the app hangs on its bootstrap spinner.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveSilentCheckSsoRedirectUri,
+  SILENT_CHECK_SSO_FILENAME
+} from '../src/utils/silentCheckSso.js';
+
+const ORIGIN = 'https://staging.dauth.me';
+const CONSOLE_BASE = '/realms/myrealm/tide-console/';
+
+test('an explicit caller-supplied URI always wins', () => {
+  const explicit = `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`;
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    configured: explicit,
+    // Even with competing signals present, the explicit value must be used verbatim.
+    baseHref: `${ORIGIN}/somewhere-else/`,
+    redirectUri: `${ORIGIN}/other/auth/redirect`
+  });
+
+  assert.equal(result.uri, explicit);
+  assert.equal(result.source, 'config');
+});
+
+test('an explicit URI survives even when it is the only thing supplied', () => {
+  const explicit = `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`;
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN, configured: explicit });
+
+  assert.equal(result.uri, explicit);
+  assert.equal(result.source, 'config');
+});
+
+test('derives a base-aware URI from a declared <base href>', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: `${ORIGIN}${CONSOLE_BASE}`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('derives the app base from the SDK `<base>auth/redirect` convention', () => {
+  // This is the exact shape a sub-path-hosted console configures.
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}${CONSOLE_BASE}auth/redirect`
+  });
+
+  // Must be `<base>/silent-check-sso.html`, NOT `<base>/auth/silent-check-sso.html`
+  // (one directory too deep) and NOT the origin root.
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri-convention');
+});
+
+test('the sub-path case never falls back to origin-root (the outage)', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}${CONSOLE_BASE}auth/redirect`
+  });
+
+  assert.notEqual(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+});
+
+test('derives from a non-conventional redirect path via its own directory', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/app/callback`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/app/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri');
+});
+
+test('BACK-COMPAT: a root-hosted app with the default redirectUri still gets origin-root', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/auth/redirect` // the SDK's own origin-root default
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'redirect-uri-convention');
+});
+
+test('BACK-COMPAT: an app declaring nothing at all still gets origin-root', () => {
+  // Every existing root-hosted consumer that configures neither a base nor a
+  // redirectUri must keep working exactly as before.
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'origin-root');
+});
+
+test('a root-level callback resolves to origin-root', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: `${ORIGIN}/callback`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+});
+
+test('<base href> takes precedence over redirectUri', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: `${ORIGIN}${CONSOLE_BASE}`,
+    redirectUri: `${ORIGIN}/elsewhere/auth/redirect`
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('a relative <base href> resolves against the origin', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    baseHref: CONSOLE_BASE
+  });
+
+  assert.equal(result.uri, `${ORIGIN}${CONSOLE_BASE}${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'base-href');
+});
+
+test('FAILS LOUD on a cross-origin redirectUri rather than guessing', () => {
+  const result = resolveSilentCheckSsoRedirectUri({
+    origin: ORIGIN,
+    redirectUri: 'https://evil.example.com/app/auth/redirect'
+  });
+
+  assert.equal(result.uri, undefined);
+  assert.equal(result.source, 'none');
+  assert.match(result.reason, /different origin/);
+});
+
+test('FAILS LOUD when there is no origin (non-browser context)', () => {
+  const result = resolveSilentCheckSsoRedirectUri({});
+
+  assert.equal(result.uri, undefined);
+  assert.equal(result.source, 'none');
+});
+
+test('an empty-string config value is not treated as supplied', () => {
+  const result = resolveSilentCheckSsoRedirectUri({ origin: ORIGIN, configured: '   ' });
+
+  // Falls through to origin-root rather than emitting an empty redirect_uri.
+  assert.equal(result.uri, `${ORIGIN}/${SILENT_CHECK_SSO_FILENAME}`);
+  assert.equal(result.source, 'origin-root');
+});

--- a/packages/tidecloak-nextjs/README.md
+++ b/packages/tidecloak-nextjs/README.md
@@ -50,7 +50,7 @@ npm install @tidecloak/nextjs
 - `verifyTideCloakToken()` - Server-side JWT verification
 - `doEncrypt()` / `doDecrypt()` - Tag-based encryption
 
-> **DPoP is enabled and enforced by default** (sender-constrained tokens). Pass `useDPoP: false` or `useDPoP: { mode: "auto" }` in your provider config to relax it — see the [`@tidecloak/js` DPoP docs](../tidecloak-js/docs/FRONT_CHANNEL.md#dpop-on-by-default).
+> **DPoP is opt-in** (sender-constrained tokens). By default you get a plain, unbound access token. Pass `useDPoP: { mode: "auto" }` or `{ mode: "strict" }` in your provider config to turn it on — see the [`@tidecloak/js` DPoP docs](../tidecloak-js/docs/FRONT_CHANNEL.md#dpop-opt-in).
 
 ---
 

--- a/packages/tidecloak-nextjs/package.json
+++ b/packages/tidecloak-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidecloak/nextjs",
-  "version": "0.12.15",
+  "version": "0.14.0",
   "description": "TideCloak nextjs SDK",
   "exports": {
     ".": {
@@ -52,8 +52,8 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@tidecloak/react": "^0.13.0",
-    "@tidecloak/verify": "^0.13.0"
+    "@tidecloak/react": "^0.14.0",
+    "@tidecloak/verify": "^0.14.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/tidecloak-react/README.md
+++ b/packages/tidecloak-react/README.md
@@ -39,4 +39,4 @@ npm install @tidecloak/react
 
 ## Security defaults
 
-**DPoP (sender-constrained tokens) is enabled and enforced by default.** No configuration is required. To relax it, pass `useDPoP` in the provider `config`: `{ mode: "auto" }` (use DPoP only when the realm supports it) or `false` (disable). See the [`@tidecloak/js` DPoP docs](../tidecloak-js/docs/FRONT_CHANNEL.md#dpop-on-by-default).
+**DPoP (sender-constrained tokens) is opt-in.** By default the SDK requests a plain, unbound access token. To turn DPoP on, pass `useDPoP` in the provider `config`: `{ mode: "auto" }` (use DPoP only when the realm supports it) or `{ mode: "strict" }` (require it). Only do so if every call carrying the token attaches a `DPoP:` proof — a bound token sent as a plain `Bearer` is rejected with a `401`. See the [`@tidecloak/js` DPoP docs](../tidecloak-js/docs/FRONT_CHANNEL.md#dpop-opt-in).

--- a/packages/tidecloak-react/package.json
+++ b/packages/tidecloak-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidecloak/react",
-  "version": "0.12.15",
+  "version": "0.14.0",
   "description": "TideCloak client-side React SDK",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -49,6 +49,6 @@
     "@types/react-dom": "^19.1.6"
   },
   "dependencies": {
-    "@tidecloak/js": "^0.13.0"
+    "@tidecloak/js": "^0.14.0"
   }
 }

--- a/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
+++ b/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
@@ -303,31 +303,90 @@ export function TideCloakContextProvider({
 
     let mounted = true;
 
+    /**
+     * Publish the SDK's auth state into React state.
+     *
+     * INVARIANT (do not break it): `authenticated === true` IMPLIES
+     * `token !== null`, in every single committed render.
+     *
+     * This function used to announce `setAuthenticated(true)` SYNCHRONOUSLY and
+     * only then `await IAMService.getToken()` to fill `token` in a later
+     * microtask. Between those two points React was free to commit a render -
+     * and it did, every time - in which the app was `authenticated` but the
+     * `token` was still `null`:
+     *
+     *   1. `initIAM()` finishes and calls `_emit("ready")`. `_emit` invokes its
+     *      listeners WITHOUT awaiting them (IAMService.js), so this async
+     *      function only gets as far as its first `await` before control returns.
+     *   2. `initIAM()` resolves -> the init effect below runs
+     *      `setIsInitializing(false)`.
+     *   3. React commits: `{ isInitializing: false, authenticated: true, token: null }`.
+     *      The app un-gates. Consumers mount and immediately fire authenticated
+     *      requests (react-query fires on subscribe).
+     *   4. A consumer reads `token` from this context, finds `null`, and sends
+     *      the request with NO `Authorization` header at all -> the resource
+     *      server answers a bare `401` that names none of this.
+     *   5. Only THEN does `getToken()` resolve and `setToken()` land - too late,
+     *      the request is already out and failed.
+     *
+     * That is the whole bug: not a stale token, not a missing DPoP proof - an
+     * authenticated-but-tokenless window that the app was invited to act in.
+     *
+     * So: resolve the token FIRST, then publish every field together. All the
+     * setState calls below sit in a single continuation, so React 18 auto-batches
+     * them into ONE commit - there is no longer any moment at which a consumer
+     * can observe `authenticated` without the `token` that makes it usable.
+     */
     const updateAuthState = async (eventName?: string) => {
       console.debug(`[TideCloak] Auth state update from: ${eventName}`);
       if (!mounted) return;
 
       const logged = IAMService.isLoggedIn();
-      setAuthenticated(logged);
 
-      if (logged) {
-        setSessionExpired(false);
-        setNeedsReauth(false);
-        try {
-          const t = await IAMService.getToken();
-          const idt = IAMService.getIDToken();
-          setToken(t);
-          setIdToken(idt);
-          setTokenExp(IAMService.getTokenExp());
-        } catch (e) {
-          console.error("[TideCloak] Failed to get tokens:", e);
-        }
-      } else {
+      if (!logged) {
+        setAuthenticated(false);
         setSessionExpired(true);
         setToken(null);
         setIdToken(null);
         setTokenExp(null);
+        return;
       }
+
+      // Logged in per the SDK - but we do not SAY so until we hold the token.
+      let t: string | null = null;
+      let idt: string | null = null;
+      let exp: number | null = null;
+      try {
+        t = await IAMService.getToken();
+        idt = IAMService.getIDToken();
+        exp = IAMService.getTokenExp();
+      } catch (e) {
+        console.error("[TideCloak] Failed to get tokens:", e);
+      }
+
+      if (!mounted) return;
+
+      // Fail CLOSED. A session we cannot produce a token for is not a session a
+      // consumer can do anything with: publishing `authenticated: true` with a
+      // null token is precisely what manufactured the 401. If the token could
+      // not be read, say we are not authenticated and let the app re-auth.
+      if (t === null) {
+        setAuthenticated(false);
+        setSessionExpired(true);
+        setToken(null);
+        setIdToken(null);
+        setTokenExp(null);
+        return;
+      }
+
+      // One batched commit: the token is in state in the SAME render that first
+      // reports `authenticated: true`.
+      setToken(t);
+      setIdToken(idt);
+      setTokenExp(exp);
+      setSessionExpired(false);
+      setNeedsReauth(false);
+      setAuthenticated(true);
     };
 
     const handleAuthSuccess = async () => {
@@ -501,6 +560,22 @@ export function TideCloakContextProvider({
         if (!loaded) throw new Error("Invalid config");
         setBaseURL((loaded['auth-server-url'] as string || '').replace(/\/+$/, ''));
         await IAMService.initIAM(resolvedConfig, updateAuthState);
+        if (!mounted) return;
+
+        // `initIAM` announces the auth state by emitting `ready`, and `_emit`
+        // fires its listeners WITHOUT awaiting them - it cannot await them, the
+        // emitter is synchronous. So `initIAM` resolving tells us the SDK has
+        // settled, but NOT that our async `updateAuthState` listener has finished
+        // writing that state into React. Clearing `isInitializing` here on the
+        // strength of `initIAM` alone is what un-gated the app one render too
+        // early, before `token` had landed.
+        //
+        // Await the auth state explicitly before we declare initialization done.
+        // `updateAuthState` is idempotent (it just re-reads the SDK and setStates
+        // the same values, which React bails out of), so running it once more
+        // costs a no-op render at worst and guarantees that by the time
+        // `isInitializing` flips to false the token is in state.
+        await updateAuthState('init');
         if (!mounted) return;
         setIsInitializing(false);
       } catch (err: any) {

--- a/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
+++ b/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
@@ -465,6 +465,33 @@ export function TideCloakContextProvider({
       .on('tokenExpired', handleTokenExpired)
       .on('initError', handleInitError as any);
 
+    // NEVER rely solely on a future event to learn the auth state.
+    //
+    // The IAMService singleton outlives this component. Whenever this effect
+    // RE-runs - a `reloadKey` bump from `reload()` / `approveTideRequests()`, a
+    // `resolvedConfig` identity change, a StrictMode double-mount - the cleanup
+    // below tears every handler down (including the `ready` handler `initIAM`
+    // registers for us) and we re-subscribe here from scratch. But the `ready`
+    // event that carried the auth state fired during the FIRST init and is long
+    // gone: an event is a moment, not a value. So the handlers we just registered
+    // would sit there hearing nothing, and this component would go on serving the
+    // `token` it happens to hold in state while the SDK refreshed its own
+    // underneath.
+    //
+    // That desync is how a `401` gets manufactured: consumers read `token` from
+    // this context and put it in an `Authorization: Bearer …` header;
+    // `IAMService.secureFetch` compares it against the token the SDK actually
+    // holds, no longer recognises it as its own, and falls back to a plain
+    // non-DPoP fetch - which a `dpop.bound.access.tokens` realm rejects outright.
+    //
+    // So: if init has already settled, read the CURRENT state synchronously right
+    // now. (`initIAM` also re-emits `ready` on its already-initialized
+    // short-circuit; this is the belt to that braces, and keeps the provider
+    // correct against an older @tidecloak/js that doesn't.)
+    if (typeof (IAMService as any).isInitialized === 'function' && (IAMService as any).isInitialized()) {
+      void updateAuthState('resubscribe');
+    }
+
     setIsInitializing(true);
 
     // Initialize

--- a/packages/tidecloak-verify/package.json
+++ b/packages/tidecloak-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidecloak/verify",
-  "version": "0.12.15",
+  "version": "0.14.0",
   "description": "A lightweight utility for server-side verification of TideCloak-issued JSON Web Tokens (JWTs).",
   "main": "./dist/cjs/TideJWT.js",
   "module": "./dist/esm/TideJWT.js",


### PR DESCRIPTION
# Summary

<!-- 
High-level overview of what is included in this release.
Mention major features, fixes, and any notable changes.
-->

### Features:
- 
  
### Bug fixes:
- 
  
---

# Release Notes
* Fixed silent re-authentication after logout so the SDK no longer opens a dokenless approval enclave.
* Made post-logout re-authentication deterministic by forcing interactive login when required and handling silent `check-sso` terminal states reliably.
* Deferred approval-enclave setup during silent initialization.
* Fixed silent `check-sso` redirect URI generation for applications hosted under a base path.
* Improved React SDK state synchronisation when the initial ready event has already fired.
* Closed the authenticated-but-tokenless window that caused temporary `401` responses on admin API calls.
* Made DPoP strictly opt-in so tokens are only DPoP-bound when explicitly requested.
* Removed incidental init-option forwarding and gated debug instrumentation for release builds.
* Updated the `tidecloak-js` packages for the `0.14.0` release.

---

# Testing

<!-- 
Explain what has been tested and how. 
Link to test runs, screenshots, or logs where relevant.
-->

### Test Types

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end / UI tests
- [ ] Manual QA
- [ ] Performance / load tests
- [ ] Other (describe):
