### PR TITLE
create-nextjs: migrate tcinit.sh to native iga-core governance (+ realm.json/TideJWT deltas)

### DIFF
--- a/packages/tidecloak-create-nextjs/TESTING-LOCAL.md
+++ b/packages/tidecloak-create-nextjs/TESTING-LOCAL.md
@@ -1,0 +1,68 @@
+# Testing the local (branch) scaffolder
+
+The public README documents `npm init @tidecloak/nextjs@latest my-app`, which pulls
+the **published** package from npm. To test the code on **this branch**
+(`agent/tcinit-native-on-main`) instead, build the package locally and run its built
+bin directly. These steps are verified.
+
+## Prerequisites
+
+- Node.js >= 18.17.0 (verified on Node 22).
+- `curl` and `jq` on PATH (required by `init/tcinit.sh`).
+- A **running TideCloak server** the scaffolder points at, *only* if you exercise the
+  realm-provisioning step. Scaffolding/file-generation works with no server; the
+  `tcinit.sh` realm/client/IGA provisioning half needs a live TideCloak.
+
+## 1. Build the package (standalone)
+
+From this package directory:
+
+```bash
+cd packages/tidecloak-create-nextjs
+npm install        # also runs the "prepare" script -> npm run build
+npm run build      # explicit rebuild (safe to re-run)
+```
+
+This produces the bin at `dist/cjs/create.cjs`. The package builds on its own; you do
+**not** need to build the sibling `@tidecloak/nextjs` package first.
+
+## 2. Run the LOCAL branch scaffolder
+
+Pick one (both verified to launch the branch's bin, not npm's registry copy):
+
+**a. Direct bin (simplest, recommended):**
+
+```bash
+node dist/cjs/create.cjs my-app
+```
+
+**b. npx against the local package path:**
+
+```bash
+npx /home/sasha/tidecloak-js/packages/tidecloak-create-nextjs my-app
+```
+
+> Do **not** use `npm link` + `npm init @tidecloak/nextjs`. `npm init` resolves the
+> initializer through `npm exec`, which does not reliably honor a globally linked
+> package and will silently fetch the **published** version from the registry. Use
+> (a) or (b) so you know you are running the branch code.
+
+The scaffolder prompts for language (TypeScript / JavaScript), copies the matching
+`template-*-app/` into `my-app`, then offers to run initialization
+(`init/tcinit.sh`). Running init requires a live TideCloak; skip it if you only want
+to verify scaffolding.
+
+## 3. Run the scaffolded app
+
+```bash
+cd my-app
+npm install
+npm run dev      # http://localhost:3000
+```
+
+## What runs under the hood
+
+The built bin resolves `packageRoot/init/tcinit.sh` and executes it via `bash`. On this
+branch that script uses the current iga-core native governance model (drains PENDING
+`iga/change-requests` via the `/approve` endpoint), tracks HTTP status through the
+`RESP_CODE` global, and sources its defaults from the co-located `init/.env.example`.

--- a/packages/tidecloak-create-nextjs/init/realm.json
+++ b/packages/tidecloak-create-nextjs/init/realm.json
@@ -80,16 +80,6 @@
                     }
                 },
                 {
-                    "name": "Tide IGA Role Mapper",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "tide-roles-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "lightweight.claim": "true",
-                        "access.token.claim": "true"
-                    }
-                },
-                {
                     "name": "Tide vuid",
                     "protocol": "openid-connect",
                     "protocolMapper": "oidc-usermodel-attribute-mapper",

--- a/packages/tidecloak-create-nextjs/init/realm.json
+++ b/packages/tidecloak-create-nextjs/init/realm.json
@@ -59,6 +59,9 @@
             "implicitFlowEnabled": false,
             "publicClient": true,
             "fullScopeAllowed": true,
+            "attributes": {
+                "tide.createdViaConsole": "true"
+            },
             "protocolMappers": [
                 {
                     "name": "Tide User Key",
@@ -100,6 +103,16 @@
                         "access.token.claim": "true",
                         "claim.name": "vuid",
                         "jsonType.label": "String"
+                    }
+                },
+                {
+                    "name": "audience (self): myclient",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "config": {
+                        "included.client.audience": "myclient",
+                        "access.token.claim": "true",
+                        "id.token.claim": "false"
                     }
                 }
             ]

--- a/packages/tidecloak-create-nextjs/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/init/tcinit.sh
@@ -2,43 +2,145 @@
 set -euo pipefail
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Determine paths
+#  @tidecloak/create-nextjs - tcinit.sh (CANONICAL copy)
+#
+#  Provisions a firstAdmin / threshold-1 Tide realm for a Next.js app, driving
+#  the CURRENT iga-core native governance model (drain PENDING change-requests
+#  via /iga/change-requests/{id}/approve, which records AND auto-commits at
+#  threshold-1). The legacy tide-admin/change-set/{type}/sign|commit path has
+#  been removed.
+#
+#  This canonical copy is invoked by create.ts as:
+#      bash "<packageRoot>/init/tcinit.sh"   (cwd = the scaffolded app dir)
+#  It resolves paths relative to PROJECT_ROOT (= packageRoot) so that create.ts
+#  can pick up the generated <packageRoot>/tidecloak.json.
+#
+#  The governance body below (from "Helper: grab a fresh master admin-cli
+#  token" onward) is IDENTICAL to the two shipped template copies under
+#  template-ts-app/init/ and template-js-app/init/. Keep them in sync via
+#  `npm run sync:init`. Only this path/bootstrap preamble differs.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─── Determine paths ─────────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# Load overrides from .env in the project root
-if [ -f "${PROJECT_ROOT}/.env.example" ]; then
-  # shellcheck disable=SC1090
-  source "${PROJECT_ROOT}/.env.example"
+# ─── Load defaults from .env.example next to the script (CRLF-safe) ──────────
+# The defaults file is co-located with this script (init/.env.example), NOT in
+# PROJECT_ROOT. -f guard keeps it a no-op when absent.
+ENV_FILE="${SCRIPT_DIR}/.env.example"
+if [[ -f "$ENV_FILE" ]]; then
+  # Apply each KEY=VALUE from the defaults file with FALLBACK semantics: a
+  # variable already present in the caller's environment is preserved and the
+  # default is ignored. We deliberately do NOT `source` the file, because raw
+  # assignments would hard-override caller-supplied env (e.g. NEW_REALM_NAME).
+  # CRLF-safe: a trailing CR is stripped from every line.
+  while IFS= read -r _env_line || [[ -n "$_env_line" ]]; do
+    _env_line="${_env_line%$'\r'}"
+    if [[ "$_env_line" =~ ^[[:space:]]*(#|$) ]]; then
+      continue
+    fi
+    if [[ "$_env_line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+      _env_key="${BASH_REMATCH[2]}"
+      _env_val="${BASH_REMATCH[3]}"
+      _env_val="${_env_val#"${_env_val%%[![:space:]]*}"}"
+      _env_val="${_env_val%"${_env_val##*[![:space:]]}"}"
+      if [[ ${#_env_val} -ge 2 && "$_env_val" == \"*\" ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      elif [[ ${#_env_val} -ge 2 && "$_env_val" == \'*\' ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      fi
+      if [[ -z "${!_env_key:-}" ]]; then
+        printf -v "$_env_key" '%s' "$_env_val"
+      fi
+    fi
+  done < "$ENV_FILE"
+  unset _env_line _env_key _env_val
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Defaults (override via env)
-# ─────────────────────────────────────────────────────────────────────────────
+# ─── Defaults (override via env) ─────────────────────────────────────────────
 TIDECLOAK_LOCAL_URL="${TIDECLOAK_LOCAL_URL:-http://localhost:8080}"
 CLIENT_APP_URL="${CLIENT_APP_URL:-http://localhost:3000}"
-REALM_JSON_PATH="${REALM_JSON_PATH:-${SCRIPT_DIR}/realm.json}"
-ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${PROJECT_ROOT}/tidecloak.json}"
 NEW_REALM_NAME="${NEW_REALM_NAME:-nextjs-test}"
-REALM_MGMT_CLIENT_ID="realm-management"
-ADMIN_ROLE_NAME="tide-realm-admin"
+REALM_MGMT_CLIENT_ID="${REALM_MGMT_CLIENT_ID:-realm-management}"
+ADMIN_ROLE_NAME="${ADMIN_ROLE_NAME:-tide-realm-admin}"
 KC_USER="${KC_USER:-admin}"
 KC_PASSWORD="${KC_PASSWORD:-password}"
 CLIENT_NAME="${CLIENT_NAME:-myclient}"
 SUBSCRIPTION_EMAIL="${SUBSCRIPTION_EMAIL:-test@demo.org}"
+ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${PROJECT_ROOT}/tidecloak.json}"
+MARKER_DIR="${PROJECT_ROOT}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# sed -i portability
-# ─────────────────────────────────────────────────────────────────────────────
-if sed --version >/dev/null 2>&1; then
-  SED_INPLACE=(-i)
-else
-  SED_INPLACE=(-i '')
+# ─── Find realm.json robustly ────────────────────────────────────────────────
+# Priority: env → same dir → parent → current working dir. A relative
+# REALM_JSON_PATH sourced from .env.example (e.g. "./realm.json") is resolved
+# against cwd first and then falls back to the copy shipped next to the script.
+CANDIDATES=()
+[[ "${REALM_JSON_PATH:-}" != "" ]] && CANDIDATES+=("${REALM_JSON_PATH}")
+CANDIDATES+=("${SCRIPT_DIR}/realm.json" "${SCRIPT_DIR}/../realm.json" "$(pwd)/realm.json")
+
+REALM_JSON_PATH=""
+for p in "${CANDIDATES[@]}"; do
+  if [[ -f "$p" ]]; then REALM_JSON_PATH="$p"; break; fi
+done
+
+if [[ -z "${REALM_JSON_PATH}" ]]; then
+  echo "ERROR: Could not find realm.json in:" >&2
+  for p in "${CANDIDATES[@]}"; do echo "   - $p" >&2; done
+  echo "   Put realm.json next to the script (${SCRIPT_DIR}/realm.json)" >&2
+  echo "   OR run with: REALM_JSON_PATH=/abs/path/realm.json bash init/tcinit.sh" >&2
+  exit 1
 fi
 
+# ─── Dependency checks ───────────────────────────────────────────────────────
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+need_cmd curl
+need_cmd jq
+need_cmd sed
+need_cmd mktemp
+
+# ─── sed -i portability ──────────────────────────────────────────────────────
+if sed --version >/dev/null 2>&1; then SED_INPLACE=(-i); else SED_INPLACE=(-i ''); fi
+
+# ─── Cleanup handler ─────────────────────────────────────────────────────────
+# INCOMPLETE_FIRSTADMIN is set to 1 once IGA is enabled (step 4) and cleared
+# back to 0 after the final grant+flip (step 14) completes. If the script exits
+# non-zero while this flag is set, the realm is half-provisioned (IGA on, admin
+# not yet granted/flipped) and we warn loudly. We do NOT auto-delete the realm.
+TMP_REALM_JSON=""
+INCOMPLETE_FIRSTADMIN=0
+cleanup() {
+  local rc=$?
+  [[ -n "${TMP_REALM_JSON}" && -f "${TMP_REALM_JSON}" ]] && rm -f "${TMP_REALM_JSON}" || true
+  [[ -f "${MARKER_DIR}/.realm_name" ]] && rm -f "${MARKER_DIR}/.realm_name" || true
+  if [[ "${rc}" != "0" && "${INCOMPLETE_FIRSTADMIN}" == "1" ]]; then
+    echo "" >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+    echo "WARNING: realm '${REALM_NAME:-?}' may be left in an incomplete firstAdmin" >&2
+    echo "         state (IGA enabled, admin not yet granted/flipped)." >&2
+    echo "         Complete provisioning or delete the realm before use." >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+  fi
+}
+trap cleanup EXIT
+
+# ─── Plaintext-to-remote credential warning (non-fatal) ──────────────────────
+# TIDECLOAK_LOCAL_URL is resolved in the preamble above. If we are about to send
+# admin credentials and bearer tokens over cleartext http:// to a NON-loopback
+# host, warn the user. Loopback http:// stays silent; https:// stays silent.
+case "${TIDECLOAK_LOCAL_URL}" in
+  http://localhost|http://localhost:*|http://localhost/*)   : ;;
+  http://127.0.0.1|http://127.0.0.1:*|http://127.0.0.1/*)   : ;;
+  http://\[::1\]|http://\[::1\]:*|http://\[::1\]/*)         : ;;
+  http://*)
+    echo "WARNING: TIDECLOAK_LOCAL_URL='${TIDECLOAK_LOCAL_URL}' uses cleartext http:// to a non-loopback host." >&2
+    echo "         Admin credentials and bearer tokens will be sent UNENCRYPTED over the network." >&2
+    echo "         Use an https:// URL when targeting a remote TideCloak." >&2
+    ;;
+esac
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Helper: grab an admin token
+#  Helper: grab a fresh master admin-cli token (master realm password grant)
 # ─────────────────────────────────────────────────────────────────────────────
 get_admin_token() {
   curl -s -X POST "${TIDECLOAK_LOCAL_URL}/realms/master/protocol/openid-connect/token" \
@@ -51,205 +153,417 @@ get_admin_token() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Step 1: prepare realm JSON
+#  Helper: status-capturing admin API call.
+#  Usage:  api METHOD URL [extra curl args...]
+#          then read the results from the globals it sets:
+#            RESP_CODE  - the HTTP status ("000" on hard network failure)
+#            RESP_BODY  - the full response body
+#  IMPORTANT: call api WITHOUT command substitution. It sets globals in the
+#  CURRENT shell; running it as `code=$(api ...)` would execute it in a subshell
+#  and the RESP_BODY/RESP_CODE it sets would be discarded before the parent
+#  could read them.
+#  - Authorization: Bearer ${TOKEN} is added automatically (refresh TOKEN first).
+#  - Never aborts the script on a non-2xx HTTP response (curl -s exits 0);
+#    only a hard network failure yields RESP_CODE "000".
 # ─────────────────────────────────────────────────────────────────────────────
+RESP_CODE=""
+RESP_BODY=""
+api() {
+  local method="$1" url="$2"; shift 2
+  local tmp
+  tmp="$(mktemp)"
+  RESP_CODE=$(curl -s -o "${tmp}" -w "%{http_code}" -X "${method}" "${url}" \
+           -H "Authorization: Bearer ${TOKEN}" "$@") || RESP_CODE="000"
+  RESP_BODY="$(cat "${tmp}")"
+  rm -f "${tmp}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Drain PENDING IGA change-requests (current iga-core native governance).
+#  LIST returns a bare JSON array; per-item id = .id; /approve body = {}
+#  (application/json). At threshold-1 /approve records AND auto-commits, so
+#  there is no separate /commit. Loop-until-empty is required because approving
+#  one CR unblocks its dependents.
+# ─────────────────────────────────────────────────────────────────────────────
+drain_change_requests() {
+  local label="${1:-}" rounds=0
+  echo "Draining PENDING change-requests ${label}..."
+  while (( rounds < 12 )); do
+    TOKEN="$(get_admin_token)"
+    local list_tmp list_code
+    list_tmp="$(mktemp)"
+    list_code=$(curl -s -o "${list_tmp}" -w "%{http_code}" \
+      "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests?status=PENDING" \
+      -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store") || list_code="000"
+    if [[ "${list_code}" == "401" || "${list_code}" == "403" ]]; then
+      rm -f "${list_tmp}"
+      echo "FATAL: change-request LIST returned HTTP ${list_code} ${label} - admin authentication/authorization failed." >&2
+      echo "       Refusing to treat an auth failure as an empty inbox. Check KC_USER/KC_PASSWORD and admin privileges." >&2
+      exit 1
+    fi
+    ids=$(jq -r '.[].id // empty' < "${list_tmp}")
+    rm -f "${list_tmp}"
+    if [[ -z "${ids}" ]]; then echo "  inbox empty ${label}"; return 0; fi
+    while IFS= read -r id; do
+      [[ -z "$id" ]] && continue
+      st=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests/${id}/approve" \
+        -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d '{}')
+      case "$st" in
+        2*) : ;;
+        401|403)
+          echo "FATAL: change-request approve ${id} returned HTTP ${st} ${label} - admin authentication/authorization failed." >&2
+          echo "       Check KC_USER/KC_PASSWORD and admin privileges." >&2
+          exit 1 ;;
+        404|409|412) : ;;
+        *) echo "  WARN approve ${id} -> ${st}" ;;
+      esac
+    done <<< "${ids}"
+    ((rounds++)) || true
+  done
+  echo "  WARN drain hit round cap ${label}"; return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 1: prepare realm JSON (placeholder substitution) + create the realm
+# ═════════════════════════════════════════════════════════════════════════════
 REALM_NAME="${NEW_REALM_NAME}"
-echo "${REALM_NAME}" > "${PROJECT_ROOT}/.realm_name"
+echo "${REALM_NAME}" > "${MARKER_DIR}/.realm_name"
 
 TMP_REALM_JSON="$(mktemp)"
 cp "${REALM_JSON_PATH}" "${TMP_REALM_JSON}"
 
-# replace placeholders
 sed "${SED_INPLACE[@]}" "s|http://localhost:3000|${CLIENT_APP_URL}|g" "${TMP_REALM_JSON}"
-sed "${SED_INPLACE[@]}" "s|nextjs-test|${REALM_NAME}|g"      "${TMP_REALM_JSON}"
-sed "${SED_INPLACE[@]}" "s|myclient|${CLIENT_NAME}|g"        "${TMP_REALM_JSON}"
+sed "${SED_INPLACE[@]}" "s|nextjs-test|${REALM_NAME}|g"               "${TMP_REALM_JSON}"
+sed "${SED_INPLACE[@]}" "s|myclient|${CLIENT_NAME}|g"                 "${TMP_REALM_JSON}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 2: create realm (allow 409 if already exists)
-# ─────────────────────────────────────────────────────────────────────────────
+# TideCloak console origin for THIS realm (used by the signed IdP settings).
+TIDE_CONSOLE_ORIGIN="${TIDECLOAK_LOCAL_URL}/realms/${REALM_NAME}/tide-console/"
+
+echo "Creating realm '${REALM_NAME}'..."
 TOKEN="$(get_admin_token)"
-echo "🌍 Creating realm..."
-status=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
   -H "Content-Type: application/json" \
-  --data-binary @"${TMP_REALM_JSON}")
-
-if [[ ${status} == 2* || ${status} -eq 409 ]]; then
-  echo "✅ Realm created (or already exists)."
+  --data-binary @"${TMP_REALM_JSON}"
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  realm create -> ${code} (created)"
+elif [[ "${code}" == "409" ]]; then
+  if [[ "${ALLOW_EXISTING_REALM:-}" == "1" ]]; then
+    echo "  WARNING: realm '${REALM_NAME}' already exists (HTTP 409); ALLOW_EXISTING_REALM=1 set, proceeding." >&2
+    echo "           NOTE: the drain step approves ALL pending change-requests in this realm," >&2
+    echo "           including any unrelated to this provisioning run." >&2
+  else
+    echo "ERROR: Realm '${REALM_NAME}' already exists; this script provisions FRESH realms and would" >&2
+    echo "       approve all pending change-requests. Set ALLOW_EXISTING_REALM=1 to override." >&2
+    exit 1
+  fi
 else
-  echo "❌ Realm creation failed (HTTP ${status})" >&2
+  echo "ERROR: realm creation failed (HTTP ${code})" >&2
+  echo "       ${RESP_BODY}" >&2
   exit 1
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 3: initialize Tide realm + IGA
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#          REQUIRES healthy ORKs. Non-2xx = fail loudly.
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Setting up Tide realm (VRK keygen on the ORK network)..."
 TOKEN="$(get_admin_token)"
-echo "🔐 Initializing Tide realm + IGA..."
-
-response=$(curl -i -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "email=${SUBSCRIPTION_EMAIL}" 2>&1)
+  --data-urlencode "email=${SUBSCRIPTION_EMAIL}" \
+  --data-urlencode "isRagnarokEnabled=true" \
+  --data-urlencode "skipLicense=false"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
+  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       Check that your ORKs are reachable and the license email is valid." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  setUpTideRealm -> ${code}"
 
-# toggle IGA
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/x-www-form-urlencoded" \
-     --data-urlencode "isIGAEnabled=true" \
-  > /dev/null
-
-echo "✅ Tide realm + IGA done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Approve & commit change-sets
-# ─────────────────────────────────────────────────────────────────────────────
-approve_and_commit() {
-  local TYPE=$1
-  echo "🔄 Processing ${TYPE} change-sets..."
-  TOKEN="$(get_admin_token)"
-  curl -s -X GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/${TYPE}/requests" \
-       -H "Authorization: Bearer ${TOKEN}" \
-    | jq -c '.[]' | while read -r req; do
-        payload=$(jq -n \
-          --arg id  "$(jq -r .draftRecordId   <<< "${req}")" \
-          --arg cst "$(jq -r .changeSetType   <<< "${req}")" \
-          --arg at  "$(jq -r .actionType      <<< "${req}")" \
-          '{changeSetId:$id,changeSetType:$cst,actionType:$at}')
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/sign" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" \
-          > /dev/null
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/commit" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" \
-          > /dev/null
-      done
-  echo "✅ ${TYPE^} change-sets done."
-}
-approve_and_commit clients
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 4: create admin user + assign role
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 3: stamp iga.attestor=tide on the realm BEFORE enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Stamping iga.attestor=tide on the realm..."
 TOKEN="$(get_admin_token)"
-echo "👤 Creating new admin user..."
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"admin","lastName":"user","enabled":true}' \
-  > /dev/null
-
-USER_ID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  | jq -r '.[0].id')
-
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  | jq -r '.[0].id')
-
-ROLE_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${CLIENT_UUID}/roles/${ADMIN_ROLE_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${CLIENT_UUID}" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "[${ROLE_JSON}]" \
-  > /dev/null
-
-echo "✅ Admin user & role done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 5: generate invite link + wait
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch realm representation (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+REALM_REP_FILE="$(mktemp)"
+jq '.attributes = ((.attributes // {}) + {"iga.attestor":"tide"})' <<< "${RESP_BODY}" > "${REALM_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "🔗 Generating invite link..."
-INVITE_LINK=$(curl -s -X POST \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=43200" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}" \
   -H "Content-Type: application/json" \
-  -d '["link-tide-account-action"]')
+  --data-binary @"${REALM_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${REALM_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to set iga.attestor=tide (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  iga.attestor=tide -> ${code}"
 
-echo "🔗 Invite link: ${INVITE_LINK}"
-echo "→ Use (or send) this URL to link the first admin to their account."
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 4: enable IGA  (application/json body {"enabled":true})
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Enabling IGA governance..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled":true}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  toggle-iga -> ${code} (IGA enabled)"
+elif [[ "${code}" == "409" ]]; then
+  echo "  toggle-iga -> 409 (already enabled)"
+else
+  echo "ERROR: toggle-iga failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
 
-MAX_TRIES=3
-attempt=1
+# From here until the final grant+flip (step 14) the realm is half-provisioned:
+# IGA is enabled but the first admin is not yet granted/flipped. A non-zero exit
+# in this window triggers the incomplete-firstAdmin warning in cleanup().
+INCOMPLETE_FIRSTADMIN=1
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 5: drain the ADOPT change-requests raised by enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after IGA enable)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 6: create the admin user (tideInvitable + emailVerified:false at create)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Creating admin user..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"Admin","lastName":"User","enabled":true,"emailVerified":false,"attributes":{"tideInvitable":["true"]}}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* || "${code}" == "201" ]]; then
+  echo "  create user -> ${code}"
+elif [[ "${code}" == "409" ]]; then
+  echo "  create user -> 409 (already exists)"
+elif [[ "${code}" == "202" ]]; then
+  echo "  create user -> 202 (IGA change-request parked)"
+else
+  echo "ERROR: admin user creation failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 7: drain (commits the CREATE_USER change-request) BEFORE resolving id
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after user create)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 8: resolve the admin userId (non-empty proves the create committed)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Resolving admin userId..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true"
+code="${RESP_CODE}"
+USER_ID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${USER_ID}" ]]; then
+  echo "ERROR: could not resolve admin userId (HTTP ${code}); the CREATE_USER change-request may not have committed." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  admin userId = ${USER_ID}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 9: mint the Tide enrollment link (link-tide-account-action)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Minting Tide enrollment link..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=3600" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/plain" \
+  -d '["link-tide-account-action"]'
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to mint enrollment link (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+INVITE_LINK="${RESP_BODY}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 10: HUMAN GATE - complete Tide enrollment in the enclave, then poll
+#           until BOTH tideUserKey and vuid attributes appear on the user.
+#           Re-fetch the admin token every iteration (master token ~60s).
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "──────────────────────────────────────────────────────────────────────"
+echo "  ACTION REQUIRED: Open this URL and complete Tide enrollment:"
+echo ""
+echo "    ${INVITE_LINK}"
+echo ""
+echo "  Enrollment happens in the Tide enclave and can take a few minutes."
+echo "  This script will wait and continue automatically once you are enrolled."
+echo "──────────────────────────────────────────────────────────────────────"
+echo ""
+
+poll_attempt=0
+POLL_MAX=100000   # effectively unbounded (~4s * 100000)
 while true; do
-  echo -n "Checking link status (attempt ${attempt}/${MAX_TRIES})… "
-  ATTRS=$(curl -s -X GET \
-    "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-    -H "Authorization: Bearer ${TOKEN}")
-
+  poll_attempt=$(( poll_attempt + 1 ))
+  TOKEN="$(get_admin_token)"
+  ATTRS=$(curl -s "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true&briefRepresentation=false" \
+    -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store")
   KEY=$(jq -r '.[0].attributes.tideUserKey[0] // empty' <<< "${ATTRS}")
   VUID=$(jq -r '.[0].attributes.vuid[0]        // empty' <<< "${ATTRS}")
-
   if [[ -n "${KEY}" && -n "${VUID}" ]]; then
-    echo "✅ Linked!"
+    echo "  Tide enrollment detected (tideUserKey + vuid present)."
     break
   fi
-
-  if (( attempt >= MAX_TRIES )); then
-    echo "⚠️  Max retries reached (${MAX_TRIES}). Moving on."
-    break
+  if (( poll_attempt >= POLL_MAX )); then
+    echo "ERROR: gave up waiting for Tide enrollment after ${poll_attempt} polls." >&2
+    exit 1
   fi
-
-  read -t 30 -p "Not linked yet; press ENTER to retry or wait 30s…" || true
-  echo
-  ((attempt++))
+  printf "  waiting for enrollment... (poll %s)\r" "${poll_attempt}"
+  sleep 4
 done
 
-approve_and_commit users
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 11: drain (commits the tideUserKey / vuid change-requests)
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after enrollment)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 6: update CustomAdminUIDomain
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 12: point the tide IdP at THIS realm's console origin, then sign it
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Signing tide IdP settings (CustomAdminUIDomain -> console origin)..."
 TOKEN="$(get_admin_token)"
-echo "🌐 Updating CustomAdminUIDomain..."
-
-INST_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-UPDATED_JSON=$(jq --arg d "${CLIENT_APP_URL}" '.config.CustomAdminUIDomain = $d' <<< "${INST_JSON}")
-
-curl -s -X PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "${UPDATED_JSON}" \
-  > /dev/null
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
-     -H "Authorization: Bearer ${TOKEN}" \
-  > /dev/null
-
-echo "✅ CustomAdminUIDomain updated + signed."
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 7: fetch adapter config + cleanup
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch tide IdP instance (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+IDP_REP_FILE="$(mktemp)"
+jq --arg d "${TIDE_CONSOLE_ORIGIN}" '.config.CustomAdminUIDomain = $d' <<< "${RESP_BODY}" > "${IDP_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "📥 Fetching adapter config…"
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  | jq -r '.[0].id')
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${IDP_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${IDP_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to update tide IdP settings (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
+  -H "Content-Type: text/plain" \
+  --data-binary ""
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: sign-idp-settings failed (HTTP ${code}). Needs healthy ORKs." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  IdP settings signed -> ${code}"
 
-curl -s -X GET \
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 13: grant tide-realm-admin to the enrolled admin (AFTER enrollment)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Granting tide-realm-admin to the admin user..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}"
+code="${RESP_CODE}"
+RM_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${RM_UUID}" ]]; then
+  echo "ERROR: could not resolve realm-management client uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${RM_UUID}/roles/${ADMIN_ROLE_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch ${ADMIN_ROLE_NAME} role (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+ROLE_REP="${RESP_BODY}"
+
+# idempotency: skip if the mapping already exists
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}"
+code="${RESP_CODE}"
+ALREADY=$(jq -r --arg r "${ADMIN_ROLE_NAME}" '[.[]?.name] | index($r) // empty' <<< "${RESP_BODY}")
+if [[ -n "${ALREADY}" ]]; then
+  echo "  ${ADMIN_ROLE_NAME} already mapped; skipping grant."
+else
+  TOKEN="$(get_admin_token)"
+  api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+    -H "Content-Type: application/json" \
+    -d "[${ROLE_REP}]"
+  code="${RESP_CODE}"
+  case "${code}" in
+    2*)  echo "  grant -> ${code}" ;;
+    202) echo "  grant -> 202 (change-request parked)" ;;
+    409)
+      echo "  grant -> 409; draining users then retrying once..."
+      drain_change_requests "(grant 409 retry)"
+      TOKEN="$(get_admin_token)"
+      api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+        -H "Content-Type: application/json" \
+        -d "[${ROLE_REP}]"
+      code="${RESP_CODE}"
+      case "${code}" in
+        2*|202|409) echo "  grant retry -> ${code}" ;;
+        *) echo "ERROR: grant retry failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+      esac
+      ;;
+    *)   echo "ERROR: grant failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+  esac
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 14: FINAL drain - commits GRANT_ROLES and flips firstAdmin->multiAdmin.
+#           No drain or governed write may run after this point.
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(final: grant + firstAdmin->multiAdmin flip)"
+
+# Grant+flip committed: the realm is fully provisioned. Clear the incomplete
+# state flag so a later non-zero exit does NOT emit the half-provisioned warning.
+INCOMPLETE_FIRSTADMIN=0
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 15: fetch the client adapter config (tidecloak.json)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Fetching adapter config..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}"
+code="${RESP_CODE}"
+CLIENT_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${CLIENT_UUID}" ]]; then
+  echo "ERROR: could not resolve client '${CLIENT_NAME}' uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+adapter_code=$(curl -s -o "${ADAPTER_OUTPUT_PATH}" -w "%{http_code}" \
   "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/get-installations-provider?clientId=${CLIENT_UUID}&providerId=keycloak-oidc-keycloak-json" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  > "${ADAPTER_OUTPUT_PATH}"
+  -H "Authorization: Bearer ${TOKEN}")
+if [[ "${adapter_code}" != 2* ]]; then
+  echo "ERROR: failed to fetch adapter config (HTTP ${adapter_code})." >&2
+  exit 1
+fi
+echo "  Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
 
-echo "✅ Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
-rm -f "${PROJECT_ROOT}/.realm_name" "${TMP_REALM_JSON}"
-
-echo "🎉 All done!"
+echo ""
+echo "All done. Realm '${REALM_NAME}' is provisioned and the first admin is enrolled."

--- a/packages/tidecloak-create-nextjs/template-js-app/init/realm.json
+++ b/packages/tidecloak-create-nextjs/template-js-app/init/realm.json
@@ -80,16 +80,6 @@
                     }
                 },
                 {
-                    "name": "Tide IGA Role Mapper",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "tide-roles-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "lightweight.claim": "true",
-                        "access.token.claim": "true"
-                    }
-                },
-                {
                     "name": "Tide vuid",
                     "protocol": "openid-connect",
                     "protocolMapper": "oidc-usermodel-attribute-mapper",

--- a/packages/tidecloak-create-nextjs/template-js-app/init/realm.json
+++ b/packages/tidecloak-create-nextjs/template-js-app/init/realm.json
@@ -59,6 +59,9 @@
             "implicitFlowEnabled": false,
             "publicClient": true,
             "fullScopeAllowed": true,
+            "attributes": {
+                "tide.createdViaConsole": "true"
+            },
             "protocolMappers": [
                 {
                     "name": "Tide User Key",
@@ -100,6 +103,16 @@
                         "access.token.claim": "true",
                         "claim.name": "vuid",
                         "jsonType.label": "String"
+                    }
+                },
+                {
+                    "name": "audience (self): myclient",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "config": {
+                        "included.client.audience": "myclient",
+                        "access.token.claim": "true",
+                        "id.token.claim": "false"
                     }
                 }
             ]

--- a/packages/tidecloak-create-nextjs/template-js-app/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/template-js-app/init/tcinit.sh
@@ -2,44 +2,73 @@
 set -euo pipefail
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Resolve script directory (run from anywhere)
+#  @tidecloak/create-nextjs - tcinit.sh (SHIPPED template copy)
+#
+#  Provisions a firstAdmin / threshold-1 Tide realm for a Next.js app, driving
+#  the CURRENT iga-core native governance model (drain PENDING change-requests
+#  via /iga/change-requests/{id}/approve, which records AND auto-commits at
+#  threshold-1). The legacy tide-admin/change-set/{type}/sign|commit path has
+#  been removed.
+#
+#  This copy ships inside the scaffolded app so the user can re-run:
+#      cd <app> && bash init/tcinit.sh
+#  It resolves everything relative to SCRIPT_DIR and is runnable from anywhere.
+#
+#  The governance body below (from "Helper: grab a fresh master admin-cli
+#  token" onward) is IDENTICAL to the canonical init/tcinit.sh. Both are kept
+#  in sync via `npm run sync:init`. Only this path/bootstrap preamble differs.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─── Resolve script directory (run from anywhere) ────────────────────────────
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Load overrides from .env.example (CRLF-safe)
-# ─────────────────────────────────────────────────────────────────────────────
+# ─── Load defaults from .env.example (CRLF-safe) ─────────────────────────────
+# -f guard keeps it a no-op when absent.
 ENV_FILE="${SCRIPT_DIR}/.env.example"
 if [[ -f "$ENV_FILE" ]]; then
-  if grep -q $'\r' "$ENV_FILE"; then
-    TMP_ENV="$(mktemp)"
-    tr -d '\r' < "$ENV_FILE" > "$TMP_ENV"
-    # shellcheck disable=SC1090
-    source "$TMP_ENV"
-    rm -f "$TMP_ENV"
-  else
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-  fi
+  # Apply each KEY=VALUE from the defaults file with FALLBACK semantics: a
+  # variable already present in the caller's environment is preserved and the
+  # default is ignored. We deliberately do NOT `source` the file, because raw
+  # assignments would hard-override caller-supplied env (e.g. NEW_REALM_NAME).
+  # CRLF-safe: a trailing CR is stripped from every line.
+  while IFS= read -r _env_line || [[ -n "$_env_line" ]]; do
+    _env_line="${_env_line%$'\r'}"
+    if [[ "$_env_line" =~ ^[[:space:]]*(#|$) ]]; then
+      continue
+    fi
+    if [[ "$_env_line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+      _env_key="${BASH_REMATCH[2]}"
+      _env_val="${BASH_REMATCH[3]}"
+      _env_val="${_env_val#"${_env_val%%[![:space:]]*}"}"
+      _env_val="${_env_val%"${_env_val##*[![:space:]]}"}"
+      if [[ ${#_env_val} -ge 2 && "$_env_val" == \"*\" ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      elif [[ ${#_env_val} -ge 2 && "$_env_val" == \'*\' ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      fi
+      if [[ -z "${!_env_key:-}" ]]; then
+        printf -v "$_env_key" '%s' "$_env_val"
+      fi
+    fi
+  done < "$ENV_FILE"
+  unset _env_line _env_key _env_val
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Defaults (override via env)
-# ─────────────────────────────────────────────────────────────────────────────
+# ─── Defaults (override via env) ─────────────────────────────────────────────
 TIDECLOAK_LOCAL_URL="${TIDECLOAK_LOCAL_URL:-http://localhost:8080}"
 CLIENT_APP_URL="${CLIENT_APP_URL:-http://localhost:3000}"
-ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${SCRIPT_DIR}/tidecloak.json}"
 NEW_REALM_NAME="${NEW_REALM_NAME:-nextjs-test}"
 REALM_MGMT_CLIENT_ID="${REALM_MGMT_CLIENT_ID:-realm-management}"
 ADMIN_ROLE_NAME="${ADMIN_ROLE_NAME:-tide-realm-admin}"
 KC_USER="${KC_USER:-admin}"
 KC_PASSWORD="${KC_PASSWORD:-password}"
 CLIENT_NAME="${CLIENT_NAME:-myclient}"
+SUBSCRIPTION_EMAIL="${SUBSCRIPTION_EMAIL:-test@demo.org}"
+ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${SCRIPT_DIR}/tidecloak.json}"
+MARKER_DIR="${SCRIPT_DIR}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Find realm.json robustly
+# ─── Find realm.json robustly ────────────────────────────────────────────────
 # Priority: env → same dir → parent → current working dir
-# ─────────────────────────────────────────────────────────────────────────────
 CANDIDATES=()
 [[ "${REALM_JSON_PATH:-}" != "" ]] && CANDIDATES+=("${REALM_JSON_PATH}")
 CANDIDATES+=("${SCRIPT_DIR}/realm.json" "${SCRIPT_DIR}/../realm.json" "$(pwd)/realm.json")
@@ -49,31 +78,64 @@ for p in "${CANDIDATES[@]}"; do
   if [[ -f "$p" ]]; then REALM_JSON_PATH="$p"; break; fi
 done
 
-echo "🔍 realm.json search candidates:"
-for p in "${CANDIDATES[@]}"; do echo "   - $p"; done
-
 if [[ -z "${REALM_JSON_PATH}" ]]; then
-  echo "❌ Could not find realm.json in the checked locations above." >&2
-  echo "   Put realm.json next to the script: ${SCRIPT_DIR}/realm.json" >&2
-  echo "   OR run with: REALM_JSON_PATH=/absolute/path/realm.json bash init/tcinit.sh" >&2
+  echo "ERROR: Could not find realm.json in:" >&2
+  for p in "${CANDIDATES[@]}"; do echo "   - $p" >&2; done
+  echo "   Put realm.json next to the script (${SCRIPT_DIR}/realm.json)" >&2
+  echo "   OR run with: REALM_JSON_PATH=/abs/path/realm.json bash init/tcinit.sh" >&2
   exit 1
 fi
-echo "✅ Using realm.json: ${REALM_JSON_PATH}"
+echo "Using realm.json: ${REALM_JSON_PATH}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Dependency checks
-# ─────────────────────────────────────────────────────────────────────────────
-need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "❌ Missing dependency: $1" >&2; exit 1; }; }
+# ─── Dependency checks ───────────────────────────────────────────────────────
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
 need_cmd curl
 need_cmd jq
 need_cmd sed
 need_cmd mktemp
 
-# sed -i portability
+# ─── sed -i portability ──────────────────────────────────────────────────────
 if sed --version >/dev/null 2>&1; then SED_INPLACE=(-i); else SED_INPLACE=(-i ''); fi
 
+# ─── Cleanup handler ─────────────────────────────────────────────────────────
+# INCOMPLETE_FIRSTADMIN is set to 1 once IGA is enabled (step 4) and cleared
+# back to 0 after the final grant+flip (step 14) completes. If the script exits
+# non-zero while this flag is set, the realm is half-provisioned (IGA on, admin
+# not yet granted/flipped) and we warn loudly. We do NOT auto-delete the realm.
+TMP_REALM_JSON=""
+INCOMPLETE_FIRSTADMIN=0
+cleanup() {
+  local rc=$?
+  [[ -n "${TMP_REALM_JSON}" && -f "${TMP_REALM_JSON}" ]] && rm -f "${TMP_REALM_JSON}" || true
+  [[ -f "${MARKER_DIR}/.realm_name" ]] && rm -f "${MARKER_DIR}/.realm_name" || true
+  if [[ "${rc}" != "0" && "${INCOMPLETE_FIRSTADMIN}" == "1" ]]; then
+    echo "" >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+    echo "WARNING: realm '${REALM_NAME:-?}' may be left in an incomplete firstAdmin" >&2
+    echo "         state (IGA enabled, admin not yet granted/flipped)." >&2
+    echo "         Complete provisioning or delete the realm before use." >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+  fi
+}
+trap cleanup EXIT
+
+# ─── Plaintext-to-remote credential warning (non-fatal) ──────────────────────
+# TIDECLOAK_LOCAL_URL is resolved in the preamble above. If we are about to send
+# admin credentials and bearer tokens over cleartext http:// to a NON-loopback
+# host, warn the user. Loopback http:// stays silent; https:// stays silent.
+case "${TIDECLOAK_LOCAL_URL}" in
+  http://localhost|http://localhost:*|http://localhost/*)   : ;;
+  http://127.0.0.1|http://127.0.0.1:*|http://127.0.0.1/*)   : ;;
+  http://\[::1\]|http://\[::1\]:*|http://\[::1\]/*)         : ;;
+  http://*)
+    echo "WARNING: TIDECLOAK_LOCAL_URL='${TIDECLOAK_LOCAL_URL}' uses cleartext http:// to a non-loopback host." >&2
+    echo "         Admin credentials and bearer tokens will be sent UNENCRYPTED over the network." >&2
+    echo "         Use an https:// URL when targeting a remote TideCloak." >&2
+    ;;
+esac
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Helper: grab an admin token
+#  Helper: grab a fresh master admin-cli token (master realm password grant)
 # ─────────────────────────────────────────────────────────────────────────────
 get_admin_token() {
   curl -s -X POST "${TIDECLOAK_LOCAL_URL}/realms/master/protocol/openid-connect/token" \
@@ -86,20 +148,82 @@ get_admin_token() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Cleanup handler
+#  Helper: status-capturing admin API call.
+#  Usage:  api METHOD URL [extra curl args...]
+#          then read the results from the globals it sets:
+#            RESP_CODE  - the HTTP status ("000" on hard network failure)
+#            RESP_BODY  - the full response body
+#  IMPORTANT: call api WITHOUT command substitution. It sets globals in the
+#  CURRENT shell; running it as `code=$(api ...)` would execute it in a subshell
+#  and the RESP_BODY/RESP_CODE it sets would be discarded before the parent
+#  could read them.
+#  - Authorization: Bearer ${TOKEN} is added automatically (refresh TOKEN first).
+#  - Never aborts the script on a non-2xx HTTP response (curl -s exits 0);
+#    only a hard network failure yields RESP_CODE "000".
 # ─────────────────────────────────────────────────────────────────────────────
-TMP_REALM_JSON=""
-cleanup() {
-  [[ -n "${TMP_REALM_JSON}" && -f "${TMP_REALM_JSON}" ]] && rm -f "${TMP_REALM_JSON}" || true
-  [[ -f "${SCRIPT_DIR}/.realm_name" ]] && rm -f "${SCRIPT_DIR}/.realm_name" || true
+RESP_CODE=""
+RESP_BODY=""
+api() {
+  local method="$1" url="$2"; shift 2
+  local tmp
+  tmp="$(mktemp)"
+  RESP_CODE=$(curl -s -o "${tmp}" -w "%{http_code}" -X "${method}" "${url}" \
+           -H "Authorization: Bearer ${TOKEN}" "$@") || RESP_CODE="000"
+  RESP_BODY="$(cat "${tmp}")"
+  rm -f "${tmp}"
 }
-trap cleanup EXIT
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Step 1: prepare realm JSON
+#  Drain PENDING IGA change-requests (current iga-core native governance).
+#  LIST returns a bare JSON array; per-item id = .id; /approve body = {}
+#  (application/json). At threshold-1 /approve records AND auto-commits, so
+#  there is no separate /commit. Loop-until-empty is required because approving
+#  one CR unblocks its dependents.
 # ─────────────────────────────────────────────────────────────────────────────
+drain_change_requests() {
+  local label="${1:-}" rounds=0
+  echo "Draining PENDING change-requests ${label}..."
+  while (( rounds < 12 )); do
+    TOKEN="$(get_admin_token)"
+    local list_tmp list_code
+    list_tmp="$(mktemp)"
+    list_code=$(curl -s -o "${list_tmp}" -w "%{http_code}" \
+      "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests?status=PENDING" \
+      -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store") || list_code="000"
+    if [[ "${list_code}" == "401" || "${list_code}" == "403" ]]; then
+      rm -f "${list_tmp}"
+      echo "FATAL: change-request LIST returned HTTP ${list_code} ${label} - admin authentication/authorization failed." >&2
+      echo "       Refusing to treat an auth failure as an empty inbox. Check KC_USER/KC_PASSWORD and admin privileges." >&2
+      exit 1
+    fi
+    ids=$(jq -r '.[].id // empty' < "${list_tmp}")
+    rm -f "${list_tmp}"
+    if [[ -z "${ids}" ]]; then echo "  inbox empty ${label}"; return 0; fi
+    while IFS= read -r id; do
+      [[ -z "$id" ]] && continue
+      st=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests/${id}/approve" \
+        -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d '{}')
+      case "$st" in
+        2*) : ;;
+        401|403)
+          echo "FATAL: change-request approve ${id} returned HTTP ${st} ${label} - admin authentication/authorization failed." >&2
+          echo "       Check KC_USER/KC_PASSWORD and admin privileges." >&2
+          exit 1 ;;
+        404|409|412) : ;;
+        *) echo "  WARN approve ${id} -> ${st}" ;;
+      esac
+    done <<< "${ids}"
+    ((rounds++)) || true
+  done
+  echo "  WARN drain hit round cap ${label}"; return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 1: prepare realm JSON (placeholder substitution) + create the realm
+# ═════════════════════════════════════════════════════════════════════════════
 REALM_NAME="${NEW_REALM_NAME}"
-echo "${REALM_NAME}" > "${SCRIPT_DIR}/.realm_name"
+echo "${REALM_NAME}" > "${MARKER_DIR}/.realm_name"
 
 TMP_REALM_JSON="$(mktemp)"
 cp "${REALM_JSON_PATH}" "${TMP_REALM_JSON}"
@@ -108,177 +232,333 @@ sed "${SED_INPLACE[@]}" "s|http://localhost:3000|${CLIENT_APP_URL}|g" "${TMP_REA
 sed "${SED_INPLACE[@]}" "s|nextjs-test|${REALM_NAME}|g"               "${TMP_REALM_JSON}"
 sed "${SED_INPLACE[@]}" "s|myclient|${CLIENT_NAME}|g"                 "${TMP_REALM_JSON}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 2: create realm (allow 409 if already exists)
-# ─────────────────────────────────────────────────────────────────────────────
-TOKEN="$(get_admin_token)"
-echo "🌍 Creating realm..."
-status=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  --data-binary @"${TMP_REALM_JSON}")
+# TideCloak console origin for THIS realm (used by the signed IdP settings).
+TIDE_CONSOLE_ORIGIN="${TIDECLOAK_LOCAL_URL}/realms/${REALM_NAME}/tide-console/"
 
-if [[ ${status} == 2* || ${status} -eq 409 ]]; then
-  echo "✅ Realm created (or already exists)."
+echo "Creating realm '${REALM_NAME}'..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_REALM_JSON}"
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  realm create -> ${code} (created)"
+elif [[ "${code}" == "409" ]]; then
+  if [[ "${ALLOW_EXISTING_REALM:-}" == "1" ]]; then
+    echo "  WARNING: realm '${REALM_NAME}' already exists (HTTP 409); ALLOW_EXISTING_REALM=1 set, proceeding." >&2
+    echo "           NOTE: the drain step approves ALL pending change-requests in this realm," >&2
+    echo "           including any unrelated to this provisioning run." >&2
+  else
+    echo "ERROR: Realm '${REALM_NAME}' already exists; this script provisions FRESH realms and would" >&2
+    echo "       approve all pending change-requests. Set ALLOW_EXISTING_REALM=1 to override." >&2
+    exit 1
+  fi
 else
-  echo "❌ Realm creation failed (HTTP ${status})" >&2
+  echo "ERROR: realm creation failed (HTTP ${code})" >&2
+  echo "       ${RESP_BODY}" >&2
   exit 1
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 3: initialize Tide realm + IGA
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#          REQUIRES healthy ORKs. Non-2xx = fail loudly.
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Setting up Tide realm (VRK keygen on the ORK network)..."
 TOKEN="$(get_admin_token)"
-echo "🔐 Initializing Tide realm + IGA..."
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "email=${SUBSCRIPTION_EMAIL:-test@demo.org}" >/dev/null
+  --data-urlencode "email=${SUBSCRIPTION_EMAIL}" \
+  --data-urlencode "isRagnarokEnabled=true" \
+  --data-urlencode "skipLicense=false"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
+  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       Check that your ORKs are reachable and the license email is valid." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  setUpTideRealm -> ${code}"
 
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/x-www-form-urlencoded" \
-     --data-urlencode "isIGAEnabled=true" >/dev/null
-
-echo "✅ Tide realm + IGA done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Approve & commit change-sets
-# ─────────────────────────────────────────────────────────────────────────────
-approve_and_commit() {
-  local TYPE=$1
-  echo "🔄 Processing ${TYPE} change-sets..."
-  TOKEN="$(get_admin_token)"
-  curl -s -X GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/${TYPE}/requests" \
-       -H "Authorization: Bearer ${TOKEN}" \
-    | jq -c '.[]' | while IFS= read -r req; do
-        payload=$(jq -n \
-          --arg id  "$(jq -r .draftRecordId   <<< "${req}")" \
-          --arg cst "$(jq -r .changeSetType   <<< "${req}")" \
-          --arg at  "$(jq -r .actionType      <<< "${req}")" \
-          '{changeSetId:$id,changeSetType:$cst,actionType:$at}')
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/sign" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" >/dev/null
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/commit" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" >/dev/null
-      done
-  echo "✅ ${TYPE^} change-sets done."
-}
-approve_and_commit clients
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 4: create admin user + assign role
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 3: stamp iga.attestor=tide on the realm BEFORE enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Stamping iga.attestor=tide on the realm..."
 TOKEN="$(get_admin_token)"
-echo "👤 Creating new admin user..."
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"admin","lastName":"user","enabled":true}' >/dev/null || true
-
-USER_ID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
-
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
-
-ROLE_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${CLIENT_UUID}/roles/${ADMIN_ROLE_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${CLIENT_UUID}" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "[${ROLE_JSON}]" >/dev/null
-
-echo "✅ Admin user & role done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 5: generate invite link + wait
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch realm representation (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+REALM_REP_FILE="$(mktemp)"
+jq '.attributes = ((.attributes // {}) + {"iga.attestor":"tide"})' <<< "${RESP_BODY}" > "${REALM_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "🔗 Generating invite link..."
-INVITE_LINK=$(curl -s -X POST \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=43200" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}" \
   -H "Content-Type: application/json" \
-  -d '["link-tide-account-action"]')
+  --data-binary @"${REALM_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${REALM_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to set iga.attestor=tide (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  iga.attestor=tide -> ${code}"
 
-echo "🔗 Invite link: ${INVITE_LINK}"
-echo "→ Send this link to the user so they can link their account."
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 4: enable IGA  (application/json body {"enabled":true})
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Enabling IGA governance..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled":true}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  toggle-iga -> ${code} (IGA enabled)"
+elif [[ "${code}" == "409" ]]; then
+  echo "  toggle-iga -> 409 (already enabled)"
+else
+  echo "ERROR: toggle-iga failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
 
-MAX_TRIES=3
-attempt=1
+# From here until the final grant+flip (step 14) the realm is half-provisioned:
+# IGA is enabled but the first admin is not yet granted/flipped. A non-zero exit
+# in this window triggers the incomplete-firstAdmin warning in cleanup().
+INCOMPLETE_FIRSTADMIN=1
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 5: drain the ADOPT change-requests raised by enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after IGA enable)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 6: create the admin user (tideInvitable + emailVerified:false at create)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Creating admin user..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"Admin","lastName":"User","enabled":true,"emailVerified":false,"attributes":{"tideInvitable":["true"]}}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* || "${code}" == "201" ]]; then
+  echo "  create user -> ${code}"
+elif [[ "${code}" == "409" ]]; then
+  echo "  create user -> 409 (already exists)"
+elif [[ "${code}" == "202" ]]; then
+  echo "  create user -> 202 (IGA change-request parked)"
+else
+  echo "ERROR: admin user creation failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 7: drain (commits the CREATE_USER change-request) BEFORE resolving id
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after user create)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 8: resolve the admin userId (non-empty proves the create committed)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Resolving admin userId..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true"
+code="${RESP_CODE}"
+USER_ID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${USER_ID}" ]]; then
+  echo "ERROR: could not resolve admin userId (HTTP ${code}); the CREATE_USER change-request may not have committed." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  admin userId = ${USER_ID}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 9: mint the Tide enrollment link (link-tide-account-action)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Minting Tide enrollment link..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=3600" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/plain" \
+  -d '["link-tide-account-action"]'
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to mint enrollment link (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+INVITE_LINK="${RESP_BODY}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 10: HUMAN GATE - complete Tide enrollment in the enclave, then poll
+#           until BOTH tideUserKey and vuid attributes appear on the user.
+#           Re-fetch the admin token every iteration (master token ~60s).
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "──────────────────────────────────────────────────────────────────────"
+echo "  ACTION REQUIRED: Open this URL and complete Tide enrollment:"
+echo ""
+echo "    ${INVITE_LINK}"
+echo ""
+echo "  Enrollment happens in the Tide enclave and can take a few minutes."
+echo "  This script will wait and continue automatically once you are enrolled."
+echo "──────────────────────────────────────────────────────────────────────"
+echo ""
+
+poll_attempt=0
+POLL_MAX=100000   # effectively unbounded (~4s * 100000)
 while true; do
-  echo -n "Checking link status (attempt ${attempt}/${MAX_TRIES})… "
-  ATTRS=$(curl -s -X GET \
-    "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-    -H "Authorization: Bearer ${TOKEN}")
-
+  poll_attempt=$(( poll_attempt + 1 ))
+  TOKEN="$(get_admin_token)"
+  ATTRS=$(curl -s "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true&briefRepresentation=false" \
+    -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store")
   KEY=$(jq -r '.[0].attributes.tideUserKey[0] // empty' <<< "${ATTRS}")
   VUID=$(jq -r '.[0].attributes.vuid[0]        // empty' <<< "${ATTRS}")
-
   if [[ -n "${KEY}" && -n "${VUID}" ]]; then
-    echo "✅ Linked!"
+    echo "  Tide enrollment detected (tideUserKey + vuid present)."
     break
   fi
-
-  if (( attempt >= MAX_TRIES )); then
-    echo "⚠️  Max retries reached (${MAX_TRIES}). Moving on."
-    break
+  if (( poll_attempt >= POLL_MAX )); then
+    echo "ERROR: gave up waiting for Tide enrollment after ${poll_attempt} polls." >&2
+    exit 1
   fi
-
-  read -t 30 -p "Not linked yet; press ENTER to retry or wait 30s…" || true
-  echo
-  ((attempt++))
+  printf "  waiting for enrollment... (poll %s)\r" "${poll_attempt}"
+  sleep 4
 done
 
-approve_and_commit users
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 11: drain (commits the tideUserKey / vuid change-requests)
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after enrollment)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 6: update CustomAdminUIDomain
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 12: point the tide IdP at THIS realm's console origin, then sign it
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Signing tide IdP settings (CustomAdminUIDomain -> console origin)..."
 TOKEN="$(get_admin_token)"
-echo "🌐 Updating CustomAdminUIDomain..."
-
-INST_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-UPDATED_JSON=$(jq --arg d "${CLIENT_APP_URL}" '.config.CustomAdminUIDomain = $d' <<< "${INST_JSON}")
-
-curl -s -X PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "${UPDATED_JSON}" >/dev/null
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
-     -H "Authorization: Bearer ${TOKEN}" >/dev/null
-
-echo "✅ CustomAdminUIDomain updated + signed."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 7: fetch adapter config
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch tide IdP instance (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+IDP_REP_FILE="$(mktemp)"
+jq --arg d "${TIDE_CONSOLE_ORIGIN}" '.config.CustomAdminUIDomain = $d' <<< "${RESP_BODY}" > "${IDP_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "📥 Fetching adapter config…"
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${IDP_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${IDP_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to update tide IdP settings (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
+  -H "Content-Type: text/plain" \
+  --data-binary ""
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: sign-idp-settings failed (HTTP ${code}). Needs healthy ORKs." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  IdP settings signed -> ${code}"
 
-curl -s -X GET \
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 13: grant tide-realm-admin to the enrolled admin (AFTER enrollment)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Granting tide-realm-admin to the admin user..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}"
+code="${RESP_CODE}"
+RM_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${RM_UUID}" ]]; then
+  echo "ERROR: could not resolve realm-management client uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${RM_UUID}/roles/${ADMIN_ROLE_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch ${ADMIN_ROLE_NAME} role (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+ROLE_REP="${RESP_BODY}"
+
+# idempotency: skip if the mapping already exists
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}"
+code="${RESP_CODE}"
+ALREADY=$(jq -r --arg r "${ADMIN_ROLE_NAME}" '[.[]?.name] | index($r) // empty' <<< "${RESP_BODY}")
+if [[ -n "${ALREADY}" ]]; then
+  echo "  ${ADMIN_ROLE_NAME} already mapped; skipping grant."
+else
+  TOKEN="$(get_admin_token)"
+  api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+    -H "Content-Type: application/json" \
+    -d "[${ROLE_REP}]"
+  code="${RESP_CODE}"
+  case "${code}" in
+    2*)  echo "  grant -> ${code}" ;;
+    202) echo "  grant -> 202 (change-request parked)" ;;
+    409)
+      echo "  grant -> 409; draining users then retrying once..."
+      drain_change_requests "(grant 409 retry)"
+      TOKEN="$(get_admin_token)"
+      api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+        -H "Content-Type: application/json" \
+        -d "[${ROLE_REP}]"
+      code="${RESP_CODE}"
+      case "${code}" in
+        2*|202|409) echo "  grant retry -> ${code}" ;;
+        *) echo "ERROR: grant retry failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+      esac
+      ;;
+    *)   echo "ERROR: grant failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+  esac
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 14: FINAL drain - commits GRANT_ROLES and flips firstAdmin->multiAdmin.
+#           No drain or governed write may run after this point.
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(final: grant + firstAdmin->multiAdmin flip)"
+
+# Grant+flip committed: the realm is fully provisioned. Clear the incomplete
+# state flag so a later non-zero exit does NOT emit the half-provisioned warning.
+INCOMPLETE_FIRSTADMIN=0
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 15: fetch the client adapter config (tidecloak.json)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Fetching adapter config..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}"
+code="${RESP_CODE}"
+CLIENT_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${CLIENT_UUID}" ]]; then
+  echo "ERROR: could not resolve client '${CLIENT_NAME}' uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+adapter_code=$(curl -s -o "${ADAPTER_OUTPUT_PATH}" -w "%{http_code}" \
   "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/get-installations-provider?clientId=${CLIENT_UUID}&providerId=keycloak-oidc-keycloak-json" \
-  -H "Authorization: Bearer ${TOKEN}" > "${ADAPTER_OUTPUT_PATH}"
+  -H "Authorization: Bearer ${TOKEN}")
+if [[ "${adapter_code}" != 2* ]]; then
+  echo "ERROR: failed to fetch adapter config (HTTP ${adapter_code})." >&2
+  exit 1
+fi
+echo "  Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
 
-echo "✅ Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
-echo "🎉 All done!"
+echo ""
+echo "All done. Realm '${REALM_NAME}' is provisioned and the first admin is enrolled."

--- a/packages/tidecloak-create-nextjs/template-ts-app/init/realm.json
+++ b/packages/tidecloak-create-nextjs/template-ts-app/init/realm.json
@@ -80,16 +80,6 @@
                     }
                 },
                 {
-                    "name": "Tide IGA Role Mapper",
-                    "protocol": "openid-connect",
-                    "protocolMapper": "tide-roles-mapper",
-                    "consentRequired": false,
-                    "config": {
-                        "lightweight.claim": "true",
-                        "access.token.claim": "true"
-                    }
-                },
-                {
                     "name": "Tide vuid",
                     "protocol": "openid-connect",
                     "protocolMapper": "oidc-usermodel-attribute-mapper",

--- a/packages/tidecloak-create-nextjs/template-ts-app/init/realm.json
+++ b/packages/tidecloak-create-nextjs/template-ts-app/init/realm.json
@@ -59,6 +59,9 @@
             "implicitFlowEnabled": false,
             "publicClient": true,
             "fullScopeAllowed": true,
+            "attributes": {
+                "tide.createdViaConsole": "true"
+            },
             "protocolMappers": [
                 {
                     "name": "Tide User Key",
@@ -100,6 +103,16 @@
                         "access.token.claim": "true",
                         "claim.name": "vuid",
                         "jsonType.label": "String"
+                    }
+                },
+                {
+                    "name": "audience (self): myclient",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "config": {
+                        "included.client.audience": "myclient",
+                        "access.token.claim": "true",
+                        "id.token.claim": "false"
                     }
                 }
             ]

--- a/packages/tidecloak-create-nextjs/template-ts-app/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/template-ts-app/init/tcinit.sh
@@ -2,44 +2,73 @@
 set -euo pipefail
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Resolve script directory (run from anywhere)
+#  @tidecloak/create-nextjs - tcinit.sh (SHIPPED template copy)
+#
+#  Provisions a firstAdmin / threshold-1 Tide realm for a Next.js app, driving
+#  the CURRENT iga-core native governance model (drain PENDING change-requests
+#  via /iga/change-requests/{id}/approve, which records AND auto-commits at
+#  threshold-1). The legacy tide-admin/change-set/{type}/sign|commit path has
+#  been removed.
+#
+#  This copy ships inside the scaffolded app so the user can re-run:
+#      cd <app> && bash init/tcinit.sh
+#  It resolves everything relative to SCRIPT_DIR and is runnable from anywhere.
+#
+#  The governance body below (from "Helper: grab a fresh master admin-cli
+#  token" onward) is IDENTICAL to the canonical init/tcinit.sh. Both are kept
+#  in sync via `npm run sync:init`. Only this path/bootstrap preamble differs.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─── Resolve script directory (run from anywhere) ────────────────────────────
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Load overrides from .env.example (CRLF-safe)
-# ─────────────────────────────────────────────────────────────────────────────
+# ─── Load defaults from .env.example (CRLF-safe) ─────────────────────────────
+# -f guard keeps it a no-op when absent.
 ENV_FILE="${SCRIPT_DIR}/.env.example"
 if [[ -f "$ENV_FILE" ]]; then
-  if grep -q $'\r' "$ENV_FILE"; then
-    TMP_ENV="$(mktemp)"
-    tr -d '\r' < "$ENV_FILE" > "$TMP_ENV"
-    # shellcheck disable=SC1090
-    source "$TMP_ENV"
-    rm -f "$TMP_ENV"
-  else
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-  fi
+  # Apply each KEY=VALUE from the defaults file with FALLBACK semantics: a
+  # variable already present in the caller's environment is preserved and the
+  # default is ignored. We deliberately do NOT `source` the file, because raw
+  # assignments would hard-override caller-supplied env (e.g. NEW_REALM_NAME).
+  # CRLF-safe: a trailing CR is stripped from every line.
+  while IFS= read -r _env_line || [[ -n "$_env_line" ]]; do
+    _env_line="${_env_line%$'\r'}"
+    if [[ "$_env_line" =~ ^[[:space:]]*(#|$) ]]; then
+      continue
+    fi
+    if [[ "$_env_line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+      _env_key="${BASH_REMATCH[2]}"
+      _env_val="${BASH_REMATCH[3]}"
+      _env_val="${_env_val#"${_env_val%%[![:space:]]*}"}"
+      _env_val="${_env_val%"${_env_val##*[![:space:]]}"}"
+      if [[ ${#_env_val} -ge 2 && "$_env_val" == \"*\" ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      elif [[ ${#_env_val} -ge 2 && "$_env_val" == \'*\' ]]; then
+        _env_val="${_env_val:1:${#_env_val}-2}"
+      fi
+      if [[ -z "${!_env_key:-}" ]]; then
+        printf -v "$_env_key" '%s' "$_env_val"
+      fi
+    fi
+  done < "$ENV_FILE"
+  unset _env_line _env_key _env_val
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Defaults (override via env)
-# ─────────────────────────────────────────────────────────────────────────────
+# ─── Defaults (override via env) ─────────────────────────────────────────────
 TIDECLOAK_LOCAL_URL="${TIDECLOAK_LOCAL_URL:-http://localhost:8080}"
 CLIENT_APP_URL="${CLIENT_APP_URL:-http://localhost:3000}"
-ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${SCRIPT_DIR}/tidecloak.json}"
 NEW_REALM_NAME="${NEW_REALM_NAME:-nextjs-test}"
 REALM_MGMT_CLIENT_ID="${REALM_MGMT_CLIENT_ID:-realm-management}"
 ADMIN_ROLE_NAME="${ADMIN_ROLE_NAME:-tide-realm-admin}"
 KC_USER="${KC_USER:-admin}"
 KC_PASSWORD="${KC_PASSWORD:-password}"
 CLIENT_NAME="${CLIENT_NAME:-myclient}"
+SUBSCRIPTION_EMAIL="${SUBSCRIPTION_EMAIL:-test@demo.org}"
+ADAPTER_OUTPUT_PATH="${ADAPTER_OUTPUT_PATH:-${SCRIPT_DIR}/tidecloak.json}"
+MARKER_DIR="${SCRIPT_DIR}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Find realm.json robustly
+# ─── Find realm.json robustly ────────────────────────────────────────────────
 # Priority: env → same dir → parent → current working dir
-# ─────────────────────────────────────────────────────────────────────────────
 CANDIDATES=()
 [[ "${REALM_JSON_PATH:-}" != "" ]] && CANDIDATES+=("${REALM_JSON_PATH}")
 CANDIDATES+=("${SCRIPT_DIR}/realm.json" "${SCRIPT_DIR}/../realm.json" "$(pwd)/realm.json")
@@ -49,31 +78,64 @@ for p in "${CANDIDATES[@]}"; do
   if [[ -f "$p" ]]; then REALM_JSON_PATH="$p"; break; fi
 done
 
-echo "🔍 realm.json search candidates:"
-for p in "${CANDIDATES[@]}"; do echo "   - $p"; done
-
 if [[ -z "${REALM_JSON_PATH}" ]]; then
-  echo "❌ Could not find realm.json in the checked locations above." >&2
-  echo "   Put realm.json next to the script: ${SCRIPT_DIR}/realm.json" >&2
-  echo "   OR run with: REALM_JSON_PATH=/absolute/path/realm.json bash init/tcinit.sh" >&2
+  echo "ERROR: Could not find realm.json in:" >&2
+  for p in "${CANDIDATES[@]}"; do echo "   - $p" >&2; done
+  echo "   Put realm.json next to the script (${SCRIPT_DIR}/realm.json)" >&2
+  echo "   OR run with: REALM_JSON_PATH=/abs/path/realm.json bash init/tcinit.sh" >&2
   exit 1
 fi
-echo "✅ Using realm.json: ${REALM_JSON_PATH}"
+echo "Using realm.json: ${REALM_JSON_PATH}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Dependency checks
-# ─────────────────────────────────────────────────────────────────────────────
-need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "❌ Missing dependency: $1" >&2; exit 1; }; }
+# ─── Dependency checks ───────────────────────────────────────────────────────
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
 need_cmd curl
 need_cmd jq
 need_cmd sed
 need_cmd mktemp
 
-# sed -i portability
+# ─── sed -i portability ──────────────────────────────────────────────────────
 if sed --version >/dev/null 2>&1; then SED_INPLACE=(-i); else SED_INPLACE=(-i ''); fi
 
+# ─── Cleanup handler ─────────────────────────────────────────────────────────
+# INCOMPLETE_FIRSTADMIN is set to 1 once IGA is enabled (step 4) and cleared
+# back to 0 after the final grant+flip (step 14) completes. If the script exits
+# non-zero while this flag is set, the realm is half-provisioned (IGA on, admin
+# not yet granted/flipped) and we warn loudly. We do NOT auto-delete the realm.
+TMP_REALM_JSON=""
+INCOMPLETE_FIRSTADMIN=0
+cleanup() {
+  local rc=$?
+  [[ -n "${TMP_REALM_JSON}" && -f "${TMP_REALM_JSON}" ]] && rm -f "${TMP_REALM_JSON}" || true
+  [[ -f "${MARKER_DIR}/.realm_name" ]] && rm -f "${MARKER_DIR}/.realm_name" || true
+  if [[ "${rc}" != "0" && "${INCOMPLETE_FIRSTADMIN}" == "1" ]]; then
+    echo "" >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+    echo "WARNING: realm '${REALM_NAME:-?}' may be left in an incomplete firstAdmin" >&2
+    echo "         state (IGA enabled, admin not yet granted/flipped)." >&2
+    echo "         Complete provisioning or delete the realm before use." >&2
+    echo "──────────────────────────────────────────────────────────────────────" >&2
+  fi
+}
+trap cleanup EXIT
+
+# ─── Plaintext-to-remote credential warning (non-fatal) ──────────────────────
+# TIDECLOAK_LOCAL_URL is resolved in the preamble above. If we are about to send
+# admin credentials and bearer tokens over cleartext http:// to a NON-loopback
+# host, warn the user. Loopback http:// stays silent; https:// stays silent.
+case "${TIDECLOAK_LOCAL_URL}" in
+  http://localhost|http://localhost:*|http://localhost/*)   : ;;
+  http://127.0.0.1|http://127.0.0.1:*|http://127.0.0.1/*)   : ;;
+  http://\[::1\]|http://\[::1\]:*|http://\[::1\]/*)         : ;;
+  http://*)
+    echo "WARNING: TIDECLOAK_LOCAL_URL='${TIDECLOAK_LOCAL_URL}' uses cleartext http:// to a non-loopback host." >&2
+    echo "         Admin credentials and bearer tokens will be sent UNENCRYPTED over the network." >&2
+    echo "         Use an https:// URL when targeting a remote TideCloak." >&2
+    ;;
+esac
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Helper: grab an admin token
+#  Helper: grab a fresh master admin-cli token (master realm password grant)
 # ─────────────────────────────────────────────────────────────────────────────
 get_admin_token() {
   curl -s -X POST "${TIDECLOAK_LOCAL_URL}/realms/master/protocol/openid-connect/token" \
@@ -86,20 +148,82 @@ get_admin_token() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Cleanup handler
+#  Helper: status-capturing admin API call.
+#  Usage:  api METHOD URL [extra curl args...]
+#          then read the results from the globals it sets:
+#            RESP_CODE  - the HTTP status ("000" on hard network failure)
+#            RESP_BODY  - the full response body
+#  IMPORTANT: call api WITHOUT command substitution. It sets globals in the
+#  CURRENT shell; running it as `code=$(api ...)` would execute it in a subshell
+#  and the RESP_BODY/RESP_CODE it sets would be discarded before the parent
+#  could read them.
+#  - Authorization: Bearer ${TOKEN} is added automatically (refresh TOKEN first).
+#  - Never aborts the script on a non-2xx HTTP response (curl -s exits 0);
+#    only a hard network failure yields RESP_CODE "000".
 # ─────────────────────────────────────────────────────────────────────────────
-TMP_REALM_JSON=""
-cleanup() {
-  [[ -n "${TMP_REALM_JSON}" && -f "${TMP_REALM_JSON}" ]] && rm -f "${TMP_REALM_JSON}" || true
-  [[ -f "${SCRIPT_DIR}/.realm_name" ]] && rm -f "${SCRIPT_DIR}/.realm_name" || true
+RESP_CODE=""
+RESP_BODY=""
+api() {
+  local method="$1" url="$2"; shift 2
+  local tmp
+  tmp="$(mktemp)"
+  RESP_CODE=$(curl -s -o "${tmp}" -w "%{http_code}" -X "${method}" "${url}" \
+           -H "Authorization: Bearer ${TOKEN}" "$@") || RESP_CODE="000"
+  RESP_BODY="$(cat "${tmp}")"
+  rm -f "${tmp}"
 }
-trap cleanup EXIT
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Step 1: prepare realm JSON
+#  Drain PENDING IGA change-requests (current iga-core native governance).
+#  LIST returns a bare JSON array; per-item id = .id; /approve body = {}
+#  (application/json). At threshold-1 /approve records AND auto-commits, so
+#  there is no separate /commit. Loop-until-empty is required because approving
+#  one CR unblocks its dependents.
 # ─────────────────────────────────────────────────────────────────────────────
+drain_change_requests() {
+  local label="${1:-}" rounds=0
+  echo "Draining PENDING change-requests ${label}..."
+  while (( rounds < 12 )); do
+    TOKEN="$(get_admin_token)"
+    local list_tmp list_code
+    list_tmp="$(mktemp)"
+    list_code=$(curl -s -o "${list_tmp}" -w "%{http_code}" \
+      "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests?status=PENDING" \
+      -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store") || list_code="000"
+    if [[ "${list_code}" == "401" || "${list_code}" == "403" ]]; then
+      rm -f "${list_tmp}"
+      echo "FATAL: change-request LIST returned HTTP ${list_code} ${label} - admin authentication/authorization failed." >&2
+      echo "       Refusing to treat an auth failure as an empty inbox. Check KC_USER/KC_PASSWORD and admin privileges." >&2
+      exit 1
+    fi
+    ids=$(jq -r '.[].id // empty' < "${list_tmp}")
+    rm -f "${list_tmp}"
+    if [[ -z "${ids}" ]]; then echo "  inbox empty ${label}"; return 0; fi
+    while IFS= read -r id; do
+      [[ -z "$id" ]] && continue
+      st=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/iga/change-requests/${id}/approve" \
+        -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d '{}')
+      case "$st" in
+        2*) : ;;
+        401|403)
+          echo "FATAL: change-request approve ${id} returned HTTP ${st} ${label} - admin authentication/authorization failed." >&2
+          echo "       Check KC_USER/KC_PASSWORD and admin privileges." >&2
+          exit 1 ;;
+        404|409|412) : ;;
+        *) echo "  WARN approve ${id} -> ${st}" ;;
+      esac
+    done <<< "${ids}"
+    ((rounds++)) || true
+  done
+  echo "  WARN drain hit round cap ${label}"; return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 1: prepare realm JSON (placeholder substitution) + create the realm
+# ═════════════════════════════════════════════════════════════════════════════
 REALM_NAME="${NEW_REALM_NAME}"
-echo "${REALM_NAME}" > "${SCRIPT_DIR}/.realm_name"
+echo "${REALM_NAME}" > "${MARKER_DIR}/.realm_name"
 
 TMP_REALM_JSON="$(mktemp)"
 cp "${REALM_JSON_PATH}" "${TMP_REALM_JSON}"
@@ -108,177 +232,333 @@ sed "${SED_INPLACE[@]}" "s|http://localhost:3000|${CLIENT_APP_URL}|g" "${TMP_REA
 sed "${SED_INPLACE[@]}" "s|nextjs-test|${REALM_NAME}|g"               "${TMP_REALM_JSON}"
 sed "${SED_INPLACE[@]}" "s|myclient|${CLIENT_NAME}|g"                 "${TMP_REALM_JSON}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 2: create realm (allow 409 if already exists)
-# ─────────────────────────────────────────────────────────────────────────────
-TOKEN="$(get_admin_token)"
-echo "🌍 Creating realm..."
-status=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  --data-binary @"${TMP_REALM_JSON}")
+# TideCloak console origin for THIS realm (used by the signed IdP settings).
+TIDE_CONSOLE_ORIGIN="${TIDECLOAK_LOCAL_URL}/realms/${REALM_NAME}/tide-console/"
 
-if [[ ${status} == 2* || ${status} -eq 409 ]]; then
-  echo "✅ Realm created (or already exists)."
+echo "Creating realm '${REALM_NAME}'..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${TMP_REALM_JSON}"
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  realm create -> ${code} (created)"
+elif [[ "${code}" == "409" ]]; then
+  if [[ "${ALLOW_EXISTING_REALM:-}" == "1" ]]; then
+    echo "  WARNING: realm '${REALM_NAME}' already exists (HTTP 409); ALLOW_EXISTING_REALM=1 set, proceeding." >&2
+    echo "           NOTE: the drain step approves ALL pending change-requests in this realm," >&2
+    echo "           including any unrelated to this provisioning run." >&2
+  else
+    echo "ERROR: Realm '${REALM_NAME}' already exists; this script provisions FRESH realms and would" >&2
+    echo "       approve all pending change-requests. Set ALLOW_EXISTING_REALM=1 to override." >&2
+    exit 1
+  fi
 else
-  echo "❌ Realm creation failed (HTTP ${status})" >&2
+  echo "ERROR: realm creation failed (HTTP ${code})" >&2
+  echo "       ${RESP_BODY}" >&2
   exit 1
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 3: initialize Tide realm + IGA
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#          REQUIRES healthy ORKs. Non-2xx = fail loudly.
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Setting up Tide realm (VRK keygen on the ORK network)..."
 TOKEN="$(get_admin_token)"
-echo "🔐 Initializing Tide realm + IGA..."
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "email=${SUBSCRIPTION_EMAIL:-test@demo.org}" >/dev/null
+  --data-urlencode "email=${SUBSCRIPTION_EMAIL}" \
+  --data-urlencode "isRagnarokEnabled=true" \
+  --data-urlencode "skipLicense=false"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
+  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       Check that your ORKs are reachable and the license email is valid." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  setUpTideRealm -> ${code}"
 
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/x-www-form-urlencoded" \
-     --data-urlencode "isIGAEnabled=true" >/dev/null
-
-echo "✅ Tide realm + IGA done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Approve & commit change-sets
-# ─────────────────────────────────────────────────────────────────────────────
-approve_and_commit() {
-  local TYPE=$1
-  echo "🔄 Processing ${TYPE} change-sets..."
-  TOKEN="$(get_admin_token)"
-  curl -s -X GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/${TYPE}/requests" \
-       -H "Authorization: Bearer ${TOKEN}" \
-    | jq -c '.[]' | while IFS= read -r req; do
-        payload=$(jq -n \
-          --arg id  "$(jq -r .draftRecordId   <<< "${req}")" \
-          --arg cst "$(jq -r .changeSetType   <<< "${req}")" \
-          --arg at  "$(jq -r .actionType      <<< "${req}")" \
-          '{changeSetId:$id,changeSetType:$cst,actionType:$at}')
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/sign" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" >/dev/null
-
-        curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/change-set/commit" \
-             -H "Authorization: Bearer ${TOKEN}" \
-             -H "Content-Type: application/json" \
-             -d "${payload}" >/dev/null
-      done
-  echo "✅ ${TYPE^} change-sets done."
-}
-approve_and_commit clients
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 4: create admin user + assign role
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 3: stamp iga.attestor=tide on the realm BEFORE enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Stamping iga.attestor=tide on the realm..."
 TOKEN="$(get_admin_token)"
-echo "👤 Creating new admin user..."
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"admin","lastName":"user","enabled":true}' >/dev/null || true
-
-USER_ID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
-
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
-
-ROLE_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${CLIENT_UUID}/roles/${ADMIN_ROLE_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${CLIENT_UUID}" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "[${ROLE_JSON}]" >/dev/null
-
-echo "✅ Admin user & role done."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 5: generate invite link + wait
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch realm representation (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+REALM_REP_FILE="$(mktemp)"
+jq '.attributes = ((.attributes // {}) + {"iga.attestor":"tide"})' <<< "${RESP_BODY}" > "${REALM_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "🔗 Generating invite link..."
-INVITE_LINK=$(curl -s -X POST \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=43200" \
-  -H "Authorization: Bearer ${TOKEN}" \
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}" \
   -H "Content-Type: application/json" \
-  -d '["link-tide-account-action"]')
+  --data-binary @"${REALM_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${REALM_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to set iga.attestor=tide (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  iga.attestor=tide -> ${code}"
 
-echo "🔗 Invite link: ${INVITE_LINK}"
-echo "→ Send this link to the user so they can link their account."
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 4: enable IGA  (application/json body {"enabled":true})
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Enabling IGA governance..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tide-admin/toggle-iga" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled":true}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* ]]; then
+  echo "  toggle-iga -> ${code} (IGA enabled)"
+elif [[ "${code}" == "409" ]]; then
+  echo "  toggle-iga -> 409 (already enabled)"
+else
+  echo "ERROR: toggle-iga failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
 
-MAX_TRIES=3
-attempt=1
+# From here until the final grant+flip (step 14) the realm is half-provisioned:
+# IGA is enabled but the first admin is not yet granted/flipped. A non-zero exit
+# in this window triggers the incomplete-firstAdmin warning in cleanup().
+INCOMPLETE_FIRSTADMIN=1
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 5: drain the ADOPT change-requests raised by enabling IGA
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after IGA enable)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 6: create the admin user (tideInvitable + emailVerified:false at create)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Creating admin user..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","email":"admin@tidecloak.com","firstName":"Admin","lastName":"User","enabled":true,"emailVerified":false,"attributes":{"tideInvitable":["true"]}}'
+code="${RESP_CODE}"
+if [[ "${code}" == 2* || "${code}" == "201" ]]; then
+  echo "  create user -> ${code}"
+elif [[ "${code}" == "409" ]]; then
+  echo "  create user -> 409 (already exists)"
+elif [[ "${code}" == "202" ]]; then
+  echo "  create user -> 202 (IGA change-request parked)"
+else
+  echo "ERROR: admin user creation failed (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 7: drain (commits the CREATE_USER change-request) BEFORE resolving id
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after user create)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 8: resolve the admin userId (non-empty proves the create committed)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Resolving admin userId..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true"
+code="${RESP_CODE}"
+USER_ID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${USER_ID}" ]]; then
+  echo "ERROR: could not resolve admin userId (HTTP ${code}); the CREATE_USER change-request may not have committed." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  admin userId = ${USER_ID}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 9: mint the Tide enrollment link (link-tide-account-action)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Minting Tide enrollment link..."
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/tideAdminResources/get-required-action-link?userId=${USER_ID}&lifespan=3600" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/plain" \
+  -d '["link-tide-account-action"]'
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to mint enrollment link (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+INVITE_LINK="${RESP_BODY}"
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 10: HUMAN GATE - complete Tide enrollment in the enclave, then poll
+#           until BOTH tideUserKey and vuid attributes appear on the user.
+#           Re-fetch the admin token every iteration (master token ~60s).
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "──────────────────────────────────────────────────────────────────────"
+echo "  ACTION REQUIRED: Open this URL and complete Tide enrollment:"
+echo ""
+echo "    ${INVITE_LINK}"
+echo ""
+echo "  Enrollment happens in the Tide enclave and can take a few minutes."
+echo "  This script will wait and continue automatically once you are enrolled."
+echo "──────────────────────────────────────────────────────────────────────"
+echo ""
+
+poll_attempt=0
+POLL_MAX=100000   # effectively unbounded (~4s * 100000)
 while true; do
-  echo -n "Checking link status (attempt ${attempt}/${MAX_TRIES})… "
-  ATTRS=$(curl -s -X GET \
-    "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin" \
-    -H "Authorization: Bearer ${TOKEN}")
-
+  poll_attempt=$(( poll_attempt + 1 ))
+  TOKEN="$(get_admin_token)"
+  ATTRS=$(curl -s "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users?username=admin&exact=true&briefRepresentation=false" \
+    -H "Authorization: Bearer ${TOKEN}" -H "Cache-Control: no-store")
   KEY=$(jq -r '.[0].attributes.tideUserKey[0] // empty' <<< "${ATTRS}")
   VUID=$(jq -r '.[0].attributes.vuid[0]        // empty' <<< "${ATTRS}")
-
   if [[ -n "${KEY}" && -n "${VUID}" ]]; then
-    echo "✅ Linked!"
+    echo "  Tide enrollment detected (tideUserKey + vuid present)."
     break
   fi
-
-  if (( attempt >= MAX_TRIES )); then
-    echo "⚠️  Max retries reached (${MAX_TRIES}). Moving on."
-    break
+  if (( poll_attempt >= POLL_MAX )); then
+    echo "ERROR: gave up waiting for Tide enrollment after ${poll_attempt} polls." >&2
+    exit 1
   fi
-
-  read -t 30 -p "Not linked yet; press ENTER to retry or wait 30s…" || true
-  echo
-  ((attempt++))
+  printf "  waiting for enrollment... (poll %s)\r" "${poll_attempt}"
+  sleep 4
 done
 
-approve_and_commit users
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 11: drain (commits the tideUserKey / vuid change-requests)
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(after enrollment)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 6: update CustomAdminUIDomain
-# ─────────────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 12: point the tide IdP at THIS realm's console origin, then sign it
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Signing tide IdP settings (CustomAdminUIDomain -> console origin)..."
 TOKEN="$(get_admin_token)"
-echo "🌐 Updating CustomAdminUIDomain..."
-
-INST_JSON=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-  -H "Authorization: Bearer ${TOKEN}")
-
-UPDATED_JSON=$(jq --arg d "${CLIENT_APP_URL}" '.config.CustomAdminUIDomain = $d' <<< "${INST_JSON}")
-
-curl -s -X PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
-     -H "Authorization: Bearer ${TOKEN}" \
-     -H "Content-Type: application/json" \
-     -d "${UPDATED_JSON}" >/dev/null
-
-curl -s -X POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
-     -H "Authorization: Bearer ${TOKEN}" >/dev/null
-
-echo "✅ CustomAdminUIDomain updated + signed."
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Step 7: fetch adapter config
-# ─────────────────────────────────────────────────────────────────────────────
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch tide IdP instance (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+IDP_REP_FILE="$(mktemp)"
+jq --arg d "${TIDE_CONSOLE_ORIGIN}" '.config.CustomAdminUIDomain = $d' <<< "${RESP_BODY}" > "${IDP_REP_FILE}"
 TOKEN="$(get_admin_token)"
-echo "📥 Fetching adapter config…"
-CLIENT_UUID=$(curl -s -X GET \
-  "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}" \
-  -H "Authorization: Bearer ${TOKEN}" | jq -r '.[0].id')
+api PUT "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/identity-provider/instances/tide" \
+  -H "Content-Type: application/json" \
+  --data-binary @"${IDP_REP_FILE}"
+code="${RESP_CODE}"
+rm -f "${IDP_REP_FILE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: failed to update tide IdP settings (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/sign-idp-settings" \
+  -H "Content-Type: text/plain" \
+  --data-binary ""
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: sign-idp-settings failed (HTTP ${code}). Needs healthy ORKs." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+echo "  IdP settings signed -> ${code}"
 
-curl -s -X GET \
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 13: grant tide-realm-admin to the enrolled admin (AFTER enrollment)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Granting tide-realm-admin to the admin user..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${REALM_MGMT_CLIENT_ID}"
+code="${RESP_CODE}"
+RM_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${RM_UUID}" ]]; then
+  echo "ERROR: could not resolve realm-management client uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients/${RM_UUID}/roles/${ADMIN_ROLE_NAME}"
+code="${RESP_CODE}"
+if [[ "${code}" != 2* ]]; then
+  echo "ERROR: could not fetch ${ADMIN_ROLE_NAME} role (HTTP ${code})." >&2
+  echo "       Response: ${RESP_BODY}" >&2
+  exit 1
+fi
+ROLE_REP="${RESP_BODY}"
+
+# idempotency: skip if the mapping already exists
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}"
+code="${RESP_CODE}"
+ALREADY=$(jq -r --arg r "${ADMIN_ROLE_NAME}" '[.[]?.name] | index($r) // empty' <<< "${RESP_BODY}")
+if [[ -n "${ALREADY}" ]]; then
+  echo "  ${ADMIN_ROLE_NAME} already mapped; skipping grant."
+else
+  TOKEN="$(get_admin_token)"
+  api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+    -H "Content-Type: application/json" \
+    -d "[${ROLE_REP}]"
+  code="${RESP_CODE}"
+  case "${code}" in
+    2*)  echo "  grant -> ${code}" ;;
+    202) echo "  grant -> 202 (change-request parked)" ;;
+    409)
+      echo "  grant -> 409; draining users then retrying once..."
+      drain_change_requests "(grant 409 retry)"
+      TOKEN="$(get_admin_token)"
+      api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/users/${USER_ID}/role-mappings/clients/${RM_UUID}" \
+        -H "Content-Type: application/json" \
+        -d "[${ROLE_REP}]"
+      code="${RESP_CODE}"
+      case "${code}" in
+        2*|202|409) echo "  grant retry -> ${code}" ;;
+        *) echo "ERROR: grant retry failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+      esac
+      ;;
+    *)   echo "ERROR: grant failed (HTTP ${code})." >&2; echo "       ${RESP_BODY}" >&2; exit 1 ;;
+  esac
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 14: FINAL drain - commits GRANT_ROLES and flips firstAdmin->multiAdmin.
+#           No drain or governed write may run after this point.
+# ═════════════════════════════════════════════════════════════════════════════
+drain_change_requests "(final: grant + firstAdmin->multiAdmin flip)"
+
+# Grant+flip committed: the realm is fully provisioned. Clear the incomplete
+# state flag so a later non-zero exit does NOT emit the half-provisioned warning.
+INCOMPLETE_FIRSTADMIN=0
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  Step 15: fetch the client adapter config (tidecloak.json)
+# ═════════════════════════════════════════════════════════════════════════════
+echo "Fetching adapter config..."
+TOKEN="$(get_admin_token)"
+api GET "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/clients?clientId=${CLIENT_NAME}"
+code="${RESP_CODE}"
+CLIENT_UUID="$(jq -r '.[0].id // empty' <<< "${RESP_BODY}")"
+if [[ -z "${CLIENT_UUID}" ]]; then
+  echo "ERROR: could not resolve client '${CLIENT_NAME}' uuid (HTTP ${code})." >&2
+  exit 1
+fi
+TOKEN="$(get_admin_token)"
+adapter_code=$(curl -s -o "${ADAPTER_OUTPUT_PATH}" -w "%{http_code}" \
   "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/get-installations-provider?clientId=${CLIENT_UUID}&providerId=keycloak-oidc-keycloak-json" \
-  -H "Authorization: Bearer ${TOKEN}" > "${ADAPTER_OUTPUT_PATH}"
+  -H "Authorization: Bearer ${TOKEN}")
+if [[ "${adapter_code}" != 2* ]]; then
+  echo "ERROR: failed to fetch adapter config (HTTP ${adapter_code})." >&2
+  exit 1
+fi
+echo "  Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
 
-echo "✅ Adapter config saved to ${ADAPTER_OUTPUT_PATH}"
-echo "🎉 All done!"
+echo ""
+echo "All done. Realm '${REALM_NAME}' is provisioned and the first admin is enrolled."

--- a/packages/tidecloak-verify/src/TideJWT.js
+++ b/packages/tidecloak-verify/src/TideJWT.js
@@ -9,6 +9,25 @@ import { jwtVerify, createLocalJWKSet, createRemoteJWKSet } from "jose";
 const DEFAULT_ALLOWED_ALGORITHMS = ["ES256", "ES384", "ES512", "EdDSA"];
 
 /**
+ * Decoded claims of a verified TideCloak access token.
+ *
+ * Standard OIDC/JWT claims are present alongside the Tide-specific claims
+ * injected by the TideCloak protocol mappers (`tideuserkey`, `vuid`). The
+ * index signature keeps arbitrary additional claims accessible (typed as
+ * `unknown`) so this type never has to be exhaustive.
+ *
+ * @typedef {Object.<string, unknown> & {
+ *   tideuserkey?: string,
+ *   vuid?: string,
+ *   sub?: string,
+ *   iss?: string,
+ *   azp?: string,
+ *   realm_access?: { roles?: string[] },
+ *   resource_access?: Object.<string, { roles?: string[] }>
+ * }} TideTokenClaims
+ */
+
+/**
  * Verify a TideCloak-issued JWT on the server side using your imported config object.
  *
  * @param {object} config - Imported TideCloak configuration (parsed JSON). May also
@@ -16,7 +35,7 @@ const DEFAULT_ALLOWED_ALGORITHMS = ["ES256", "ES384", "ES512", "EdDSA"];
  *   (number of seconds, or a jose duration string) to tune verification.
  * @param {string} token - access token to verify.
  * @param {string[]} [allowedRoles] - Array of Tidecloak realm or client roles; user must have at least one.
- * @returns {Promise<object|null>} - The token payload if valid and role-check passes, otherwise null.
+ * @returns {Promise<TideTokenClaims|null>} - The token claims if valid and role-check passes, otherwise null.
  */
 export async function verifyTideCloakToken(config, token, allowedRoles = []) {
   try {
@@ -74,7 +93,7 @@ export async function verifyTideCloakToken(config, token, allowedRoles = []) {
       }
     }
 
-    return payload;
+    return /** @type {TideTokenClaims} */ (payload);
   } catch (err) {
     // Log only the message (not the error object, which can echo token-derived
     // data). Note: this collapses both invalid tokens and infrastructure failures


### PR DESCRIPTION
## Summary
Migrates the `@tidecloak/create-nextjs` provisioning script off the legacy `tide-admin/change-set/*` governance API (which 404s on current iga-core) onto the native `iga/change-requests` + `/approve` inbox, plus small realm.json and type deltas. Built as a curated branch off `main` (main independently rewrote these files; this PR ports only the non-regressing delta).

## Changes
- **tcinit.sh** (canonical + both template copies): native `iga/change-requests` drain, `iga.attestor=tide` stamp before `toggle-iga`, drain all ADOPT CRs, create admin user with `tideInvitable`, grant `tide-realm-admin` after Tide-link and commit last (firstAdmin→multiAdmin flip). Hardening: fatal 401/403 in the drain, `ALLOW_EXISTING_REALM` re-run guard, partial-run warning, plaintext-URL warning, enrollment-link lifespan 1h, real HTTP-status assertions, `CustomAdminUIDomain`=console origin, `api()` via shell globals (not a command-substitution subshell), `.env.example` fallback loader. Preserves main's `SUBSCRIPTION_EMAIL` default and realms.json resolver.
- **realm.json** (3 copies): on top of main's file, adds `tide.createdViaConsole` + a self-audience mapper and removes the `tide-roles-mapper` (absent from the authoritative idp-extensions frontend `realmTemplate.ts` and unused by the scaffolded app); keeps main's `_tide_message.*` roles.
- **TideJWT.js** (`@tidecloak/verify`): types `verifyTideCloakToken`'s return with a `TideTokenClaims` typedef (`tideuserkey`/`vuid`), on top of main's algorithm-pinning hardening (unchanged).
- **TESTING-LOCAL.md**: how to run the scaffolder from a local build.

## Testing
- Validated live to the enrollment gate on a current-inbox stack: realm create, setUpTideRealm, attestor stamp, toggle-iga, native ADOPT drain, admin-user+tideInvitable, link mint (the post-enrollment flip needs an enclave login, not run here).
- DPoP serving was tested both ways under `next dev` and `next build/start`: main's existing route handler is clean in all cases; this PR keeps it and makes no DPoP change.

## Not included
The unrelated base-branch SDK rewrite (`tidecloak.js`/`IAMService.js`/`tidecloak-server`) is intentionally excluded — main rewrote those independently.

