### PR TITLE
tidecloak-js: fix CJS dist/types so @tidecloak/react builds on TS7 (follow-up to #105)

### DIFF
--- a/packages/tidecloak-js/scripts/postbuild.cjs
+++ b/packages/tidecloak-js/scripts/postbuild.cjs
@@ -2,6 +2,17 @@
 // interprets each build correctly regardless of the root package.json "type"
 // (this package is "type":"module", so dist/cjs/*.js would otherwise be parsed
 // as ESM and break `require()`).
+//
+// dist/types is marked "commonjs" on purpose. The exports map serves the same
+// dist/types/*.d.ts under BOTH the "import" and "require" conditions, so its
+// declared module format must be one a CommonJS consumer can `require`. Without
+// this marker the declarations inherit the root "type":"module" and are seen as
+// ESM, which makes any CommonJS build that imports this package under TypeScript
+// 7 (moduleResolution node16/nodenext) fail with TS1479 ("ECMAScript module ...
+// cannot be imported with require") - e.g. @tidecloak/react's dist/cjs build.
+// CommonJS-typed declarations are consumable from BOTH CommonJS and ESM (ESM can
+// import CJS), so this is safe for ESM consumers too. Mirrors how `jose` ships a
+// single CommonJS-typed .d.ts reused by both conditions.
 const fs = require("fs");
 const path = require("path");
 
@@ -13,3 +24,4 @@ const writeMarker = (dir, type) => {
 
 writeMarker("dist/cjs", "commonjs");
 writeMarker("dist/esm", "module");
+writeMarker("dist/types", "commonjs");


### PR DESCRIPTION
## Why

PR #105 (the tsconfig node16 sweep, now merged) set `@tidecloak/react`'s `dist/cjs` build to `module`/`moduleResolution: node16`. That change was verified with `tsc --noEmit` **without** `node_modules` installed, so `@tidecloak/js` never resolved and a real error was never surfaced.

With a **real** `npm run build` (deps installed, TypeScript 7.0.2) it fails:

```
src/contexts/TideCloakContextProvider.tsx(2,53): error TS1479: ... the referenced file (@tidecloak/js) is an ECMAScript module and cannot be imported with 'require' ...
src/hooks/useAuthCallback.ts(3,28): TS1479 ...
src/index.tsx(7,79) / (14,42): TS1479 ...
```

## Root cause (in @tidecloak/js, not react)

`@tidecloak/js` is `"type":"module"` and its `exports` map serves a **single** `dist/types/*.d.ts` under both the `import` and `require` conditions. `postbuild.cjs` writes `{"type":"commonjs"}` into `dist/cjs` and `{"type":"module"}` into `dist/esm`, but left `dist/types` unmarked, so the declarations inherited the root `"type":"module"` and TypeScript treated the package as **ESM-typed**. Under TS7's node16 resolver (node10 removed), any CommonJS build importing it hits TS1479 — `@tidecloak/react`'s `dist/cjs` being the first case, and any external CJS consumer being a latent one.

react is correctly kept on `node16/node16` (consistent with its commonjs-root siblings `@tidecloak/verify` and `@tidecloak/nextjs`); the defect was the dependency's packaging.

## Fix

`postbuild.cjs` also writes `dist/types/package.json` = `{"type":"commonjs"}`. CommonJS-typed declarations are consumable from both CommonJS and ESM (ESM can import CJS), so ESM consumers are unaffected. This mirrors how `jose` ships a single CommonJS-typed `.d.ts` reused by both conditions. The marker ships in the published tarball (`dist` is in `files`).

## Verification — real `npm run build`, deps installed, tsc 7.0.2

| Package | Result |
|---|---|
| @tidecloak/js | PASS |
| @tidecloak/verify | PASS |
| @tidecloak/react | PASS (was FAIL) |
| @tidecloak/nextjs | PASS |
| @tidecloak/create-nextjs | PASS |
| @tidecloak/server | N/A (no package.json / build script) |

Note: from now on these must be verified with real `npm run build` (deps installed), not `tsc --noEmit`.

## Publish-order note

There is no npm workspace; each package resolves `@tidecloak/*` deps from the registry at build time. The react build only picks up this fix once `@tidecloak/js` is **republished** with it, so releases must publish `@tidecloak/js` before `@tidecloak/react`.