### PR TITLE
tidecloak-react: fix native-Node ESM import (add .js extensions); flag @tideorg/js CJS issue as out-of-repo

### DIFF
--- a/packages/tidecloak-react/src/components/AuthCallback.tsx
+++ b/packages/tidecloak-react/src/components/AuthCallback.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAuthCallback, UseAuthCallbackOptions } from '../hooks/useAuthCallback';
+import { useAuthCallback, UseAuthCallbackOptions } from '../hooks/useAuthCallback.js';
 
 export interface AuthCallbackProps extends UseAuthCallbackOptions {
   /**

--- a/packages/tidecloak-react/src/contexts/TideCloakProvider.tsx
+++ b/packages/tidecloak-react/src/contexts/TideCloakProvider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, FC } from "react";
-import { TideCloakContextProvider } from "./TideCloakContextProvider";
+import { TideCloakContextProvider } from "./TideCloakContextProvider.js";
 
 interface TideCloakProviderProps {
   config: Record<string, any>;

--- a/packages/tidecloak-react/src/index.tsx
+++ b/packages/tidecloak-react/src/index.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { useTideCloakContext } from './contexts/TideCloakContextProvider';
-import type { TideCloakContextValue, TideCloakContextProviderProps } from './contexts/TideCloakContextProvider';
+import { useTideCloakContext } from './contexts/TideCloakContextProvider.js';
+import type { TideCloakContextValue, TideCloakContextProviderProps } from './contexts/TideCloakContextProvider.js';
 
-export { TideCloakContextProvider } from './contexts/TideCloakContextProvider';
-export type { TideCloakContextValue, TideCloakContextProviderProps, ActionNotification, ActionNotificationType } from './contexts/TideCloakContextProvider';
+export { TideCloakContextProvider } from './contexts/TideCloakContextProvider.js';
+export type { TideCloakContextValue, TideCloakContextProviderProps, ActionNotification, ActionNotificationType } from './contexts/TideCloakContextProvider.js';
 export type { NativeAdapter, NativeTokenData, NativeAuthCallbackResult } from "@tidecloak/js";
 
 // Hybrid mode utilities
-export { useAuthCallback, parseCallbackUrl } from './hooks/useAuthCallback';
-export type { AuthCallbackState, UseAuthCallbackOptions } from './hooks/useAuthCallback';
-export { AuthCallback, SimpleAuthCallback } from './components/AuthCallback';
-export type { AuthCallbackProps } from './components/AuthCallback';
+export { useAuthCallback, parseCallbackUrl } from './hooks/useAuthCallback.js';
+export type { AuthCallbackState, UseAuthCallbackOptions } from './hooks/useAuthCallback.js';
+export { AuthCallback, SimpleAuthCallback } from './components/AuthCallback.js';
+export type { AuthCallbackProps } from './components/AuthCallback.js';
 export { RequestEnclave, AdminAPI } from "@tidecloak/js";
 
 /**


### PR DESCRIPTION
## Summary

Fixes one of two latent raw-Node runtime issues that were fine under bundlers (Next/webpack/vite) but broke a native Node `import`/`require` of the published packages. Both were verified with real builds + real Node runtime checks; only the react one is fixable in this repo.

### Issue B (FIXED here) — @tidecloak/react ESM used extensionless relative specifiers

`@tidecloak/react`'s ESM build (`dist/esm`, marked `{"type":"module"}` by postbuild) emitted relative imports without `.js` extensions. Node's native ESM loader rejects these:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/esm/contexts/TideCloakContextProvider' imported from .../dist/esm/index.js
```

**Fix:** add explicit `.js` extensions to all relative import/export specifiers in the react source (`src/index.tsx`, `src/components/AuthCallback.tsx`, `src/contexts/TideCloakProvider.tsx`). This is node16/nodenext-correct and emits verbatim under both tsconfigs, so `dist/cjs` still emits extensionless-safe `require("./….js")` and `dist/esm` emits ESM-valid `from './….js'`.

**Verification (real Node, TS 7.0.2):**
- Before: native ESM import failed with `ERR_MODULE_NOT_FOUND` on `./contexts/TideCloakContextProvider`.
- After: in an isolated sandbox (with `@tidecloak/js` stubbed to isolate Issue A), `await import('@tidecloak/react')` succeeds and returns all 17 exports; `require('@tidecloak/react')` (cjs) likewise returns all 17 exports.
- Full build matrix green on TS7: `verify`, `js` (cjs+esm+types), `react` (cjs+esm), `nextjs` (built against the local fixed react), `create-nextjs`.

### Issue A (NOT fixed here — out-of-repo, needs a user/crypto-owner decision)

`@tidecloak/js`'s CJS output does `require("@tideorg/js")`, and a raw-Node `require('@tidecloak/js')` fails. Root cause is **inside `@tideorg/js` (the separate tide-js repo), not tidecloak-js**:

`@tideorg/js@0.13.21` ships ESM syntax (`export * as Clients from './Clients'`) but its `package.json` has **no `"type"` field** (defaults to CommonJS) and uses **extensionless directory** imports. Node 22 syntax-detection sees `export`, treats `index.js` as ESM, then its `./Clients` directory imports fail:

```
Error: Directory import '.../@tideorg/js/dist/Clients' is not supported resolving ES modules ...
```

This fails identically under **both** `require('@tideorg/js')` **and** `import('@tideorg/js')`. Consequences:
- Option (a) "switch @tidecloak/js CJS to dynamic `import()`" does **not** help — dynamic import of `@tideorg/js` fails the same way (proven).
- Option (b) "make @tidecloak/js ESM-only" does **not** help either, and is a breaking change with no benefit.
- The **only** real fix is in `@tideorg/js`/tide-js: add `"type":"module"` **and** explicit directory index paths (`./Clients/index.js`), or ship a proper dual CJS+ESM build.

In practice `@tidecloak/js` is always consumed via a bundler (react/nextjs/create-nextjs, all Next contexts), which resolves `@tideorg/js` fine, so this is latent. **Recommendation:** track the fix in the tide-js/`@tideorg/js` repo; no change to tidecloak-js is warranted or possible for Issue A.

## Test plan

- [x] `npm run build` for all 5 packages on TS 7.0.2
- [x] Real Node native-ESM `import('@tidecloak/react')` succeeds post-fix (isolated sandbox)
- [x] Real Node `require('@tidecloak/react')` (cjs) succeeds post-fix
- [x] nextjs builds against the local fixed react
