### PR TITLE
create-nextjs: 'Cybersecurity Fabric' wording + run on app-url port + post-link success message

### DIFF
--- a/packages/tidecloak-create-nextjs/create.ts
+++ b/packages/tidecloak-create-nextjs/create.ts
@@ -116,6 +116,30 @@ async function main(): Promise<void> {
         input.trim().length > 0 || 'Please enter your app URL'
     })
 
+    // Pin the generated app to the port from the app URL so it actually runs
+    // there (redirectUris/webOrigins already use the full URL incl. port). If
+    // the URL has no explicit port (e.g. a bare https domain), leave the
+    // template defaults so Next falls back to its default port (3000).
+    let appPort = ''
+    try {
+      appPort = new URL(clientAppUrl.trim()).port
+    } catch {
+      // Non-URL input: leave defaults, redirectUris config handles the rest.
+    }
+    if (appPort) {
+      try {
+        const appPkgPath = path.resolve(process.cwd(), targetDir, 'package.json')
+        const appPkg = JSON.parse(fs.readFileSync(appPkgPath, 'utf8'))
+        appPkg.scripts = appPkg.scripts || {}
+        appPkg.scripts.dev = `next dev -p ${appPort}`
+        appPkg.scripts.start = `next start -p ${appPort}`
+        fs.writeFileSync(appPkgPath, JSON.stringify(appPkg, null, 2) + '\n')
+        console.log(`Configured app to run on port ${appPort} (from ${clientAppUrl.trim()})`)
+      } catch (err: any) {
+        console.warn(`Could not pin app port ${appPort}: ${err.message}`)
+      }
+    }
+
     const { kcUser } = await prompt<{ kcUser: string }>({
       type: 'input',
       name: 'kcUser',

--- a/packages/tidecloak-create-nextjs/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/init/tcinit.sh
@@ -265,10 +265,10 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#  Step 2: setUpTideRealm (mints the realm VRK on the Tide Cybersecurity Fabric)
 #          REQUIRES healthy ORKs. Non-2xx = fail loudly.
 # ═════════════════════════════════════════════════════════════════════════════
-echo "Setting up Tide realm (VRK keygen on the ORK network)..."
+echo "Setting up Tide realm (VRK keygen on the Tide Cybersecurity Fabric)..."
 TOKEN="$(get_admin_token)"
 api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -278,7 +278,7 @@ api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setU
 code="${RESP_CODE}"
 if [[ "${code}" != 2* ]]; then
   echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
-  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       This step needs a healthy Cybersecurity Fabric (VRK keygen)." >&2
   echo "       Check that your ORKs are reachable and the license email is valid." >&2
   echo "       Response: ${RESP_BODY}" >&2
   exit 1

--- a/packages/tidecloak-create-nextjs/template-js-app/app/auth/redirect/page.jsx
+++ b/packages/tidecloak-create-nextjs/template-js-app/app/auth/redirect/page.jsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTideCloak } from '@tidecloak/nextjs';
 
 export default function RedirectPage() {
   const { authenticated, isInitializing, logout } = useTideCloak()
   const router = useRouter()
+  // Landing message after the Tide account link completes. Overridden on the
+  // token-expiry failure path so we never claim success while signing out.
+  const [message, setMessage] = useState('Tide Account Linked Successfully')
 
   // Handles redirect when middleware detects token expiry
   useEffect(() => {
@@ -18,6 +21,7 @@ export default function RedirectPage() {
     const auth = params.get("auth");
 
     if (auth === "failed") {
+      setMessage('Signing you out...')
       sessionStorage.setItem("tokenExpired", "true");
       doLogOut();
     }
@@ -31,7 +35,7 @@ export default function RedirectPage() {
 
   return (
     <div style={containerStyle}>
-      <p>Waiting for authentication...</p>
+      <p>{message}</p>
     </div>
   )
 }

--- a/packages/tidecloak-create-nextjs/template-js-app/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/template-js-app/init/tcinit.sh
@@ -260,10 +260,10 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#  Step 2: setUpTideRealm (mints the realm VRK on the Tide Cybersecurity Fabric)
 #          REQUIRES healthy ORKs. Non-2xx = fail loudly.
 # ═════════════════════════════════════════════════════════════════════════════
-echo "Setting up Tide realm (VRK keygen on the ORK network)..."
+echo "Setting up Tide realm (VRK keygen on the Tide Cybersecurity Fabric)..."
 TOKEN="$(get_admin_token)"
 api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -273,7 +273,7 @@ api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setU
 code="${RESP_CODE}"
 if [[ "${code}" != 2* ]]; then
   echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
-  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       This step needs a healthy Cybersecurity Fabric (VRK keygen)." >&2
   echo "       Check that your ORKs are reachable and the license email is valid." >&2
   echo "       Response: ${RESP_BODY}" >&2
   exit 1

--- a/packages/tidecloak-create-nextjs/template-ts-app/app/auth/redirect/page.tsx
+++ b/packages/tidecloak-create-nextjs/template-ts-app/app/auth/redirect/page.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTideCloak } from '@tidecloak/nextjs';
 
 export default function RedirectPage() {
   const { authenticated, isInitializing, logout } = useTideCloak()
   const router = useRouter()
+  // Landing message after the Tide account link completes. Overridden on the
+  // token-expiry failure path so we never claim success while signing out.
+  const [message, setMessage] = useState('Tide Account Linked Successfully')
 
   // Handles redirect when middleware detects token expiry
   useEffect(() => {
@@ -18,6 +21,7 @@ export default function RedirectPage() {
     const auth = params.get("auth");
 
     if (auth === "failed") {
+      setMessage('Signing you out...')
       sessionStorage.setItem("tokenExpired", "true");
       doLogOut();
     }
@@ -31,7 +35,7 @@ export default function RedirectPage() {
 
   return (
     <div style={containerStyle}>
-      <p>Waiting for authentication...</p>
+      <p>{message}</p>
     </div>
   )
 }

--- a/packages/tidecloak-create-nextjs/template-ts-app/init/tcinit.sh
+++ b/packages/tidecloak-create-nextjs/template-ts-app/init/tcinit.sh
@@ -260,10 +260,10 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-#  Step 2: setUpTideRealm (mints the realm VRK on the ORK network)
+#  Step 2: setUpTideRealm (mints the realm VRK on the Tide Cybersecurity Fabric)
 #          REQUIRES healthy ORKs. Non-2xx = fail loudly.
 # ═════════════════════════════════════════════════════════════════════════════
-echo "Setting up Tide realm (VRK keygen on the ORK network)..."
+echo "Setting up Tide realm (VRK keygen on the Tide Cybersecurity Fabric)..."
 TOKEN="$(get_admin_token)"
 api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setUpTideRealm" \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -273,7 +273,7 @@ api POST "${TIDECLOAK_LOCAL_URL}/admin/realms/${REALM_NAME}/vendorResources/setU
 code="${RESP_CODE}"
 if [[ "${code}" != 2* ]]; then
   echo "ERROR: setUpTideRealm failed (HTTP ${code})." >&2
-  echo "       This step needs a healthy ORK network (VRK keygen)." >&2
+  echo "       This step needs a healthy Cybersecurity Fabric (VRK keygen)." >&2
   echo "       Check that your ORKs are reachable and the license email is valid." >&2
   echo "       Response: ${RESP_BODY}" >&2
   exit 1


### PR DESCRIPTION
## Summary
Three user-facing improvements to `@tidecloak/create-nextjs`:

### 1. Wording: "ORK network" -> "Cybersecurity Fabric"
The tcinit provisioning step that mints the realm VRK now uses Tide's public term "Cybersecurity Fabric" in user-facing text instead of "ORK network". Applied identically to all three tcinit.sh copies (canonical `init/`, `template-ts-app/init/`, `template-js-app/init/`), keeping their governance body byte-identical. Only echo/comment strings changed; no variables, endpoints, env vars, or code identifiers were renamed.

### 2. Scaffolded app deploys on the app-url's port
`create.ts` now parses the port from the app URL supplied during scaffolding (via `new URL(appUrl).port`). When a numeric port is present it pins the generated app's `dev`/`start` scripts (`next dev -p <port>` / `next start -p <port>`); when absent (bare domain) the template defaults are left untouched so Next falls back to its default port (3000). This makes the scaffolded app actually run on the same port already used for redirectUris/webOrigins.

### 3. Post-link redirect page shows "Tide Account Linked Successfully"
The page the user lands on after completing the Tide account link is the template's own `app/auth/redirect/page.{tsx,jsx}` (IAMService defaults the login redirect_uri to `<origin>/auth/redirect`). It previously rendered "Waiting for authentication..."; it now renders exactly **Tide Account Linked Successfully**. The token-expiry failure path (`?auth=failed`, triggered by the middleware onError redirect) shows "Signing you out..." instead, so the success text never appears while logging out. Change is in the TEMPLATE pages only; the shared `@tidecloak/react` `AuthCallback`/`useAuthCallback` component was NOT touched (the templates don't use it).

## Verification
- `bash -n` clean on all 3 tcinit.sh; `jq empty` clean on all 3 realm.json (untouched by any change).
- CLI builds (`npm run build` -> dist/cjs/create.cjs + dist/esm/create.js).
- Real scaffold via the built CLI (PTY-driven, provisioning pointed at a dead server so it fails after files are generated):
  - `http://localhost:3007` (TS) -> `dev: next dev -p 3007`, `start: next start -p 3007`
  - `http://localhost:3009` (JS) -> `dev: next dev -p 3009`, `start: next start -p 3009`
  - `https://myapp.example.com` (no port) -> scripts unchanged (`next dev` / `next start`), i.e. default 3000
- Post-link message: exact string `Tide Account Linked Successfully` present in both `template-ts-app/app/auth/redirect/page.tsx` and `template-js-app/app/auth/redirect/page.jsx`; no stale "Waiting for authentication" text remains; the two pages differ only in the TS `React.CSSProperties` type annotation. Templates are copied verbatim into scaffolded apps.