### PR TITLE
create-nextjs: clear high-severity npm audit findings in scaffolded apps

### DIFF
--- a/packages/tidecloak-create-nextjs/template-js-app/package.json
+++ b/packages/tidecloak-create-nextjs/template-js-app/package.json
@@ -13,5 +13,9 @@
     "react": "19.x",
     "react-dom": "19.x",
     "@tidecloak/nextjs": "^0.13.11"
+  },
+  "overrides": {
+    "postcss": "^8.5.25",
+    "sharp": "^0.35.3"
   }
 }

--- a/packages/tidecloak-create-nextjs/template-ts-app/package.json
+++ b/packages/tidecloak-create-nextjs/template-ts-app/package.json
@@ -14,6 +14,10 @@
     "react-dom": "19.x",
     "@tidecloak/nextjs": "^0.13.11"
   },
+  "overrides": {
+    "postcss": "^8.5.25",
+    "sharp": "^0.35.3"
+  },
   "devDependencies": {
     "@types/node": "24.0.13",
     "@types/react": "19.1.8",


### PR DESCRIPTION
## Problem
`npm install` in an app scaffolded from `@tidecloak/create-nextjs` produced **4 npm audit findings (1 moderate, 3 HIGH)**. The user requires **no HIGH** vulnerabilities in scaffolded apps.

## Root cause
All 4 findings trace to two transitive deps pulled in by `next@16`:

| Package | Severity | Advisory | Path | Fixed in |
|---|---|---|---|---|
| postcss | HIGH | GHSA-qx2v-qp2m-jg93, GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849 | transitive via `next` (pinned `8.4.31`) | > 8.5.17 |
| sharp | HIGH | GHSA-f88m-g3jw-g9cj (libvips CVEs) | transitive via `next` (`^0.34.5`) | >= 0.35.0 |
| next | HIGH | (no own advisory) flagged only for depending on vulnerable postcss+sharp | direct dep | n/a |
| @tidecloak/nextjs | moderate | flagged only for depending on `next` | direct dep | n/a |

`next` is already at the latest 16.x (16.2.12) and pins `postcss@8.4.31` exactly + `sharp@^0.34.5`, so a direct `next`/SDK bump cannot clear these — `overrides` are the correct tool.

## Fix
Add `overrides` to both `template-ts-app` and `template-js-app` package.json:

```json
"overrides": {
  "postcss": "^8.5.25",
  "sharp": "^0.35.3"
}
```

## Verification (real, fresh installs from the edited template files)
- `template-ts-app`: `npm audit` -> **found 0 vulnerabilities** (0 high / 0 critical / 0 moderate / 0 low)
- `template-js-app`: `npm audit` -> **found 0 vulnerabilities**
- Build: `template-js-app` `npm run build` compiles + generates static pages clean. `template-ts-app` compiles clean (postcss/sharp overrides are build-neutral); its `next build` fails only on a **pre-existing** TypeScript type error in `app/home/page.tsx:31` (`tcConfig["realm"]` indexing type `{}`) that also fails on the unmodified template — not introduced by this change. Flagged separately.
- Scaffolder `@tidecloak/create-nextjs` own deps audit: 0 vulnerabilities (no change needed).

## Flagged for follow-up (out of scope for this PR)
Pre-existing TS build failure in `template-ts-app/app/home/page.tsx:31` — `hasRealmRole(\`default-roles-${tcConfig["realm"]}\`)` indexes an object typed `{}`. Present before this change; should be fixed separately.
