### PR TITLE
create-nextjs: TS template builds clean (typed adapter config) + revert redirect success string

### DIFF
--- a/packages/tidecloak-create-nextjs/template-js-app/app/auth/redirect/page.jsx
+++ b/packages/tidecloak-create-nextjs/template-js-app/app/auth/redirect/page.jsx
@@ -7,9 +7,10 @@ import { useTideCloak } from '@tidecloak/nextjs';
 export default function RedirectPage() {
   const { authenticated, isInitializing, logout } = useTideCloak()
   const router = useRouter()
-  // Landing message after the Tide account link completes. Overridden on the
-  // token-expiry failure path so we never claim success while signing out.
-  const [message, setMessage] = useState('Tide Account Linked Successfully')
+  // Generic landing message shown briefly after any login while auth resolves.
+  // Overridden on the token-expiry failure path so we never claim success while
+  // signing out.
+  const [message, setMessage] = useState('Waiting for authentication...')
 
   // Handles redirect when middleware detects token expiry
   useEffect(() => {

--- a/packages/tidecloak-create-nextjs/template-ts-app/app/auth/redirect/page.tsx
+++ b/packages/tidecloak-create-nextjs/template-ts-app/app/auth/redirect/page.tsx
@@ -7,9 +7,10 @@ import { useTideCloak } from '@tidecloak/nextjs';
 export default function RedirectPage() {
   const { authenticated, isInitializing, logout } = useTideCloak()
   const router = useRouter()
-  // Landing message after the Tide account link completes. Overridden on the
-  // token-expiry failure path so we never claim success while signing out.
-  const [message, setMessage] = useState('Tide Account Linked Successfully')
+  // Generic landing message shown briefly after any login while auth resolves.
+  // Overridden on the token-expiry failure path so we never claim success while
+  // signing out.
+  const [message, setMessage] = useState('Waiting for authentication...')
 
   // Handles redirect when middleware detects token expiry
   useEffect(() => {

--- a/packages/tidecloak-create-nextjs/template-ts-app/app/home/page.tsx
+++ b/packages/tidecloak-create-nextjs/template-ts-app/app/home/page.tsx
@@ -1,8 +1,14 @@
 'use client'
 
 import { useTideCloak } from '@tidecloak/nextjs'
+import type { TidecloakConfig } from '@tidecloak/nextjs/server'
 import { useState, useCallback, useEffect } from 'react'
-import tcConfig from "../../tidecloak.json"
+import rawConfig from "../../tidecloak.json"
+
+// tidecloak.json is a placeholder ({}) until `npm run init` provisions the realm
+// and writes the real adapter config. Type it via the SDK's own config shape so
+// fields like `realm` type-check regardless of the placeholder's contents.
+const tcConfig = rawConfig as TidecloakConfig
 
 
 export default function HomePage() {

--- a/packages/tidecloak-create-nextjs/template-ts-app/middleware.ts
+++ b/packages/tidecloak-create-nextjs/template-ts-app/middleware.ts
@@ -2,7 +2,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { createTideCloakMiddleware } from "@tidecloak/nextjs/server";
-import tcConfig from "./tidecloak.json";
+import type { TidecloakConfig } from "@tidecloak/nextjs/server";
+import rawConfig from "./tidecloak.json";
+
+// tidecloak.json is a placeholder ({}) until `npm run init` provisions the realm
+// and writes the real adapter config. Type it via the SDK's own config shape so
+// the middleware options type-check regardless of the placeholder's contents.
+const tcConfig = rawConfig as TidecloakConfig;
 
 export default createTideCloakMiddleware({
   config: tcConfig,


### PR DESCRIPTION
Follow-up to #116 (already merged), which introduced two issues into `main`:

1. **The TypeScript template did not `npm run build` clean.** A freshly scaffolded TS app failed the `next build` type-check:
   - `app/home/page.tsx:31` — `hasRealmRole(\`default-roles-${tcConfig["realm"]}\`)` — `tcConfig` is imported from the placeholder `tidecloak.json` (`{}` until `npm run init` provisions), so it is typed `{}` and `["realm"]` errors: *"Element implicitly has an 'any' type because expression of type '\"realm\"' can't be used to index type '{}'"*.
   - `middleware.ts` — `createTideCloakMiddleware({ config: tcConfig, ... })`: the SDK's `TideMiddlewareOptions.config` is the strict `TidecloakConfig` (requires `realm`, etc.), which `{}` does not satisfy (latent, masked by the home error surfacing first).

   **Fix (template-local, no hacks):** type the `tidecloak.json` import via the SDK's own exported `TidecloakConfig` (`import type { TidecloakConfig } from '@tidecloak/nextjs/server'; const tcConfig = rawConfig as TidecloakConfig`). No `as any`, no `@ts-ignore`, no disabling of `next build` type-checking. A typed assertion to the SDK's own config interface is the correct idiom here because a JSON-module type reflects the placeholder file contents, not the real runtime shape.

2. **`app/auth/redirect/page.tsx` said "Tide Account Linked Successfully".** That route is shown briefly after *any* login, so it must not claim account-link success. The real post-link confirmation is a TideCloak login-theme (server-side) page, handled separately. Reverted the landing message to the generic `Waiting for authentication...` in both templates. The token-expiry "Signing you out..." failure path is unchanged.

## Verification
Real scaffold via the CLI (dead-server init so only the app files generate) then real `npm install && npm run build`:
- **Result: CLEAN — exit 0, `Compiled successfully`, `Finished TypeScript` (0 type errors), all 6 routes generated** including `/auth/redirect`, `npm install` reports 0 vulnerabilities (with the #118 overrides in place).
- `/auth/redirect` prerenders `Waiting for authentication...`; the old string is absent from `.next`.
- Versions: Next.js 16.2.12 (Turbopack), TypeScript 5.8.3, React 19.2.8.

## Parity
JS template (`template-js-app`) uses the config untyped at runtime (no type-check), so only the redirect-message revert applies there; behaviour is equivalent.
