### PR TITLE
Clear all npm audit findings across packages (postcss/sharp overrides)

### DIFF
--- a/packages/tidecloak-nextjs/package.json
+++ b/packages/tidecloak-nextjs/package.json
@@ -60,5 +60,9 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "next": "^15.0.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.25",
+    "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
## Goal
`npm install` reports **0 vulnerabilities** (all severities) in every package of the monorepo. Extends PR #118 (postcss/sharp overrides in the two template apps) to the remaining packages.

## Audit sweep (real `npm install` + `npm audit` in each package)

| Package | Before | Fix | After |
|---|---|---|---|
| `packages/tidecloak-js` | 0 | none | 0 |
| `packages/tidecloak-verify` | 0 | none | 0 |
| `packages/tidecloak-react` | 0 | none | 0 |
| `packages/tidecloak-create-nextjs` | 0 | none | 0 |
| `packages/tidecloak-create-nextjs/template-ts-app` | 0 (already fixed in #118) | none | 0 |
| `packages/tidecloak-create-nextjs/template-js-app` | 0 (already fixed in #118) | none | 0 |
| `packages/tidecloak-nextjs` | **3 high** | overrides added | **0** |

### tidecloak-nextjs findings (before)
- `postcss <=8.5.17` (high) — GHSA-qx2v-qp2m-jg93, GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849. Transitive via `next` (devDependency).
- `sharp <0.35.0` (high) — GHSA-f88m-g3jw-g9cj (libvips CVE-2026-33327/33328/35590/35591). Transitive via `next` (devDependency).

### Fix
Added the same overrides #118 used in the templates, keeping the whole monorepo consistent:
```json
"overrides": {
  "postcss": "^8.5.25",
  "sharp": "^0.35.3"
}
```
No direct-dependency bumps were needed anywhere; all findings were transitive and cleared by pinning patched versions via `overrides`. No breaking/major bumps required.

## Verification (real installs + builds, from clean `node_modules`)
- `npm audit` -> `found 0 vulnerabilities` in **all 7** packages.
- `tidecloak-nextjs` `prepare` build (tsc cjs+esm) succeeds with the override.
- `template-ts-app` real `next build` (Next 16 / React 19) succeeds.
- `template-js-app` real `next build` succeeds.
- Build artifacts (`next-env.d.ts`, `next`-reconfigured `tsconfig.json`) were reverted, not committed.

## Out of scope / pre-existing (NOT an audit finding)
`tidecloak-react`'s `prepare` build fails on a standalone `npm install` (TS1479: the CJS build cannot `require` the ESM `@tidecloak/js@0.13.x` resolved from npm). This is pre-existing on `main`, unrelated to any dependency vulnerability, and untouched by this PR (react audit is already 0). Flagging for a separate decision.
