### PR TITLE
tidecloak-react: expose executeTideRequest

### DIFF
--- a/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
+++ b/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
@@ -73,6 +73,16 @@ export interface TideCloakContextValue {
   secureFetch: (url: string | URL | RequestInfo, init?: RequestInit) => Promise<Response>;
   // Tide request signing (for policy creation)
   initializeTideRequest: <T extends { encode: () => Uint8Array }>(request: T) => Promise<T>
+  /**
+   * Send an initialised request to the Tide network and get back its signatures.
+   *
+   * The other half of initializeTideRequest. Initialising a request without being able to run it
+   * leaves a caller holding something they can do nothing with, which is why this is here.
+   *
+   * The request is passed through untouched, so any model the network accepts works - including a
+   * custom one, which the network matches by the shape of its id rather than from a list.
+   */
+  executeTideRequest: (request: { encode: () => Uint8Array } | Uint8Array, waitForAll?: boolean) => Promise<Uint8Array[]>
   getVendorId: () => string
   getResource: () => string
 
@@ -794,6 +804,21 @@ export function TideCloakContextProvider({
       return request;
     },
 
+    // Sending an initialised request to be signed. The counterpart to initializeTideRequest.
+    executeTideRequest: async (
+      request: { encode: () => Uint8Array } | Uint8Array,
+      waitForAll: boolean = false
+    ): Promise<Uint8Array[]> => {
+      const tc = (IAMService as any)._tc;
+      if (!tc?.executeSignRequest) {
+        throw new Error("TideCloak executeSignRequest not available");
+      }
+      // Encoded bytes or something that can encode itself, since a caller who has already
+      // initialised a request is holding bytes rather than an object.
+      const encoded = request instanceof Uint8Array ? request : request.encode();
+      return await tc.executeSignRequest(encoded, waitForAll);
+    },
+
     // Get vendor ID from config
     getVendorId: () => {
       const cfg = IAMService.getConfig() as any;
@@ -920,6 +945,7 @@ const defaultContextValue: TideCloakContextValue = {
   doDecrypt: async () => null,
   secureFetch: (url: string | URL | RequestInfo, init?: RequestInit) => fetch(url, init),
   initializeTideRequest: async () => { throw new Error("TideCloakContextProvider not available"); },
+  executeTideRequest: async () => { throw new Error("TideCloakContextProvider not available"); },
   getVendorId: () => "",
   getResource: () => "",
   approveTideRequests: async () => { throw new Error("TideCloakContextProvider not available"); },


### PR DESCRIPTION
`initializeTideRequest` is reachable from the context and its counterpart is not, so a caller can
prepare a request and then has no supported way to run it.

The underlying client has had both all along — only one was passed through. This adds the other.

## Why it has gone unnoticed

`doEncrypt` and `doDecrypt` never touch the second call, so nothing in the common path exercises
it. The gap only appears when an application needs a model other than encryption.

At that point everything else is already in place:

- `RequestEnclave.execute` takes request bytes and a sign flow and **does not inspect the model** —
  there is no whitelist to be on.
- `BaseTideRequest(name, version, authFlow, draft)` takes a free-form name and version, so a
  custom model constructs fine.

So a custom model works today, as long as an application can reach the call. Through this package
it could not.

## The change

Twenty-six lines, following `initializeTideRequest` exactly: the type on the context, the
implementation beside its twin using the same `(IAMService as any)._tc` access, and the
"provider not available" default.

It accepts encoded bytes **or** something that can encode itself, because a caller who has just
called `initializeTideRequest` is holding bytes rather than an object.

## Checked

`tsc -p tsconfig.esm.json` is clean.

The CommonJS build reports four `TS1479` module-interop errors. Those are pre-existing and
unrelated: reverting this change and rebuilding gives the same four.

## Where it is used

A just-in-time access credential in MediQuill. A signed policy authorises someone to mint a
short-lived pass for one case; the pass is a `BasicCustom<JitToken>` request, initialised and then
signed through this path. Without the second call the browser can build and initialise that
request and go no further.
