### PR TITLE
tidecloak-react: forward the decryption policy to encrypt and decrypt

### DIFF
--- a/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
+++ b/packages/tidecloak-react/src/contexts/TideCloakContextProvider.tsx
@@ -66,8 +66,12 @@ export interface TideCloakContextValue {
   resetWasOffline: () => void;
 
   // Tide actions
-  doEncrypt: (data: any) => Promise<any>;
-  doDecrypt: (data: any) => Promise<any>;
+  //
+  // decryptionPolicy is the SIGNED policy bytes that guard the data. Passing one is what makes the
+  // orks run a contract over the request (PolicyEnabledEncryption:1 / PolicyEnabledDecryption:1)
+  // instead of encrypting under the caller's key alone; omit it and there is no contract to run.
+  doEncrypt: (data: any, decryptionPolicy?: Uint8Array) => Promise<any>;
+  doDecrypt: (data: any, decryptionPolicy?: Uint8Array) => Promise<any>;
 
   // DPoP-aware fetch
   secureFetch: (url: string | URL | RequestInfo, init?: RequestInit) => Promise<Response>;
@@ -734,10 +738,10 @@ export function TideCloakContextProvider({
     
     secureFetch: (url: string | URL | RequestInfo, init?: RequestInit) =>
       isInitializing ? fetch(url, init) : IAMService.secureFetch(url, init),
-    doEncrypt: async (data: any) => {
+    doEncrypt: async (data: any, decryptionPolicy?: Uint8Array) => {
       if (isInitializing) return null;
       try {
-        const result = await IAMService.doEncrypt(data);
+        const result = await IAMService.doEncrypt(data, decryptionPolicy ?? undefined);
         onActionNotificationRef.current?.({
           type: 'success',
           title: 'Encrypted',
@@ -756,10 +760,10 @@ export function TideCloakContextProvider({
         throw error;
       }
     },
-    doDecrypt: async (data: any) => {
+    doDecrypt: async (data: any, decryptionPolicy?: Uint8Array) => {
       if (isInitializing) return null;
       try {
-        const result = await IAMService.doDecrypt(data);
+        const result = await IAMService.doDecrypt(data, decryptionPolicy ?? undefined);
         onActionNotificationRef.current?.({
           type: 'success',
           title: 'Decrypted',


### PR DESCRIPTION
## Summary

`IAMService.doEncrypt` and `doDecrypt` both take a second argument: the signed policy bytes that guard the data. The React wrapper declared and accepted only the first, and called through with only the first — so from `@tidecloak/react` there was no way to pass one.

## Why this is not a missing convenience

**Passing a policy is what makes the orks run a contract over the request.** `PolicyEnabledEncryption:1` and `PolicyEnabledDecryption:1` are the model ids a contract branches on. Without a policy the data is encrypted under the caller's key alone and no contract runs — so an application whose access rules live in a Forseti contract could not reach them through this package at all. The rules would be written, signed, deployed, and never consulted.

## Changes

- `encrypt` and `decrypt` on the context take an optional policy and forward it.
- Optional, so every existing caller is unchanged and still encrypts without one.
- Typed `Uint8Array` to match what `@tidecloak/js` actually declares rather than what would be convenient here — passing `null` instead of omitting is a type error there, so the wrapper normalises `undefined` through.

## Pre-existing, and untouched

**This package does not currently build.** Four TS1479 CommonJS/ESM import errors are present on a clean `main` — in `index.tsx`, `useAuthCallback.ts`, and this file's own import line. This change neither adds to them nor fixes them, and is not the right place to.
